### PR TITLE
Recipe Registering, Screens, Material names and Sounds

### DIFF
--- a/mappings/net/minecraft/block/BedBlock.mapping
+++ b/mappings/net/minecraft/block/BedBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_158 net/minecraft/block/BedBlock
+	FIELD field_570 BED_TYPE Lnet/minecraft/class_390;
+	FIELD field_571 OCCUPIED Lnet/minecraft/class_388;
 	CLASS class_159 BedBlockType
 		FIELD field_572 HEAD Lnet/minecraft/class_158$class_159;
 		FIELD field_573 FOOT Lnet/minecraft/class_158$class_159;

--- a/mappings/net/minecraft/block/BigMushroomBlock.mapping
+++ b/mappings/net/minecraft/block/BigMushroomBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_234 net/minecraft/block/BigMushroomBlock
+	FIELD field_984 VARIANT Lnet/minecraft/class_390;
 	CLASS class_235 MushroomType
 		FIELD field_1000 TYPES [Lnet/minecraft/class_234$class_235;
 		FIELD field_1001 id I
@@ -22,4 +23,3 @@ CLASS net/minecraft/class_234 net/minecraft/block/BigMushroomBlock
 		METHOD method_883 getId ()I
 		METHOD method_884 getById (I)Lnet/minecraft/class_234$class_235;
 			ARG 0 id
-		METHOD values ()[Lnet/minecraft/class_234$class_235;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -1,10 +1,11 @@
 CLASS net/minecraft/class_160 net/minecraft/block/Block
-	FIELD field_577 boundingBoxX D
-	FIELD field_578 boundingBoxY D
-	FIELD field_579 boundingBoxZ D
-	FIELD field_580 boundingBoxX2 D
-	FIELD field_581 boundingBoxY2 D
-	FIELD field_582 boundingBoxZ2 D
+	COMMENT Air, the filler block
+	FIELD field_577 boundingBoxMinX D
+	FIELD field_578 boundingBoxMinY D
+	FIELD field_579 boundingBoxMinZ D
+	FIELD field_580 boundingBoxMaxX D
+	FIELD field_581 boundingBoxMaxY D
+	FIELD field_582 boundingBoxMaxZ D
 	FIELD field_583 sound Lnet/minecraft/class_160$class_162;
 	FIELD field_585 material Lnet/minecraft/class_591;
 	FIELD field_586 materialColor Lnet/minecraft/class_592;
@@ -30,6 +31,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	FIELD field_607 SLIME Lnet/minecraft/class_160$class_162;
 	FIELD field_608 opaque Z
 	FIELD field_611 lightLevel I
+	FIELD field_613 strength F
+	FIELD field_614 resistance F
 	FIELD field_616 tickRandomly Z
 	METHOD <init> (Lnet/minecraft/class_591;)V
 		ARG 1 material
@@ -43,7 +46,14 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_633 setup ()V
 	METHOD method_634 getTranslationKey ()Ljava/lang/String;
 	METHOD method_635 setLightLevel (F)Lnet/minecraft/class_160;
+		ARG 1 lightLevel
 	METHOD method_636 setBoundingBox (FFFFFF)V
+		ARG 1 minX
+		ARG 2 minY
+		ARG 3 minZ
+		ARG 4 maxX
+		ARG 5 maxY
+		ARG 6 maxZ
 	METHOD method_637 stateFromData (I)Lnet/minecraft/class_376;
 		ARG 1 data
 	METHOD method_638 register (ILjava/lang/String;Lnet/minecraft/class_160;)V
@@ -54,6 +64,9 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 explosion
 	METHOD method_642 getTickRate (Lnet/minecraft/class_99;)I
 		ARG 1 world
+	METHOD method_643 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
+		ARG 1 world
+		ARG 2 pos
 	METHOD method_644 onDestroyedByExplosion (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_93;)V
 		ARG 1 world
 		ARG 2 pos
@@ -122,14 +135,20 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 pos
 		ARG 3 facing
 	METHOD method_669 setSound (Lnet/minecraft/class_160$class_162;)Lnet/minecraft/class_160;
+		ARG 1 sound
 	METHOD method_670 getIdByBlock (Lnet/minecraft/class_160;)I
 		ARG 0 block
 	METHOD method_672 getMeta (Lnet/minecraft/class_376;)I
 		ARG 1 state
-	METHOD method_674 getDropItem (Lnet/minecraft/class_376;Ljava/util/Random;I)Lnet/minecraft/class_2054;
+	METHOD method_673 (Lnet/minecraft/class_376;Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)Lnet/minecraft/class_376;
 		ARG 1 state
+		ARG 3 pos
+	METHOD method_674 getDropItem (Lnet/minecraft/class_376;Ljava/util/Random;I)Lnet/minecraft/class_2054;
+		ARG 1 blockState
 		ARG 2 random
+		ARG 3 state
 	METHOD method_677 getDropCount (Ljava/util/Random;)I
+		ARG 1 rand
 	METHOD method_679 calcBlockBreakingData (Lnet/minecraft/class_1963;Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
 	METHOD method_680 setItemGroup (Lnet/minecraft/class_2029;)Lnet/minecraft/class_160;
 	METHOD method_681 getBlockFromItem (Lnet/minecraft/class_2054;)Lnet/minecraft/class_160;
@@ -141,6 +160,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_683 setTickRandomly (Z)Lnet/minecraft/class_160;
 		ARG 1 tickRandomly
 	METHOD method_685 setResistance (F)Lnet/minecraft/class_160;
+		ARG 1 resistance
+	METHOD method_686 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Lnet/minecraft/class_646;
+		ARG 1 world
+		ARG 2 pos
 	METHOD method_687 dropExperience (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;I)V
 		ARG 1 world
 		ARG 2 pos
@@ -179,6 +202,9 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_717 getByBlockState (Lnet/minecraft/class_376;)I
 		ARG 0 state
 	METHOD method_718 canMobSpawnInside ()Z
+	METHOD method_719 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
+		ARG 1 world
+		ARG 2 pos
 	METHOD method_720 getMaterialColor (Lnet/minecraft/class_376;)Lnet/minecraft/class_592;
 		ARG 1 state
 	METHOD method_721 getAmbientOcclusionLightLevel ()F
@@ -199,6 +225,7 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_737 getMaterial ()Lnet/minecraft/class_591;
 	METHOD method_738 isFullCube ()Z
 	METHOD method_741 setUnbreakable ()Lnet/minecraft/class_160;
+	METHOD method_742 ticksRandomly ()Z
 	CLASS class_161 OffsetType
 		FIELD field_617 NONE Lnet/minecraft/class_160$class_161;
 		FIELD field_618 XZ Lnet/minecraft/class_160$class_161;

--- a/mappings/net/minecraft/block/Blocks.mapping
+++ b/mappings/net/minecraft/block/Blocks.mapping
@@ -38,6 +38,7 @@ CLASS net/minecraft/class_163 net/minecraft/block/Blocks
 	FIELD field_660 CACTUS Lnet/minecraft/class_169;
 	FIELD field_661 CLAY Lnet/minecraft/class_160;
 	FIELD field_662 AIR Lnet/minecraft/class_160;
+		COMMENT
 	FIELD field_663 SUGARCANE Lnet/minecraft/class_291;
 	FIELD field_664 JUKEBOX Lnet/minecraft/class_160;
 	FIELD field_665 OAK_FENCE Lnet/minecraft/class_160;
@@ -91,6 +92,7 @@ CLASS net/minecraft/class_163 net/minecraft/block/Blocks
 	FIELD field_713 LIT_REDSTONE_LAMP Lnet/minecraft/class_160;
 	FIELD field_714 DOBULE_WOODEN_SLAB Lnet/minecraft/class_226;
 	FIELD field_715 STONE Lnet/minecraft/class_160;
+		COMMENT
 	FIELD field_716 WOODEN_SLAB Lnet/minecraft/class_226;
 	FIELD field_717 COCOA Lnet/minecraft/class_160;
 	FIELD field_718 SANDSTONE_STAIRS Lnet/minecraft/class_160;

--- a/mappings/net/minecraft/block/CakeBlock.mapping
+++ b/mappings/net/minecraft/block/CakeBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_170 net/minecraft/block/CakeBlock
+	FIELD field_828 BITES Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -1,8 +1,13 @@
 CLASS net/minecraft/class_591 net/minecraft/block/Material
+	FIELD field_2175 CACTUS Lnet/minecraft/class_591;
 	FIELD field_2176 CLAY Lnet/minecraft/class_591;
+	FIELD field_2177 PUMPKIN Lnet/minecraft/class_591;
 	FIELD field_2178 EGG Lnet/minecraft/class_591;
 	FIELD field_2179 PORTAL Lnet/minecraft/class_591;
+	FIELD field_2180 CAKE Lnet/minecraft/class_591;
 	FIELD field_2181 COBWEB Lnet/minecraft/class_591;
+	FIELD field_2182 PISTON Lnet/minecraft/class_591;
+	FIELD field_2183 BARRIER Lnet/minecraft/class_591;
 	FIELD field_2184 burnable Z
 	FIELD field_2187 color Lnet/minecraft/class_592;
 	FIELD field_2188 blocksMovement Z
@@ -18,14 +23,27 @@ CLASS net/minecraft/class_591 net/minecraft/block/Material
 	FIELD field_2200 FOILAGE Lnet/minecraft/class_591;
 	FIELD field_2201 PLANT Lnet/minecraft/class_591;
 	FIELD field_2202 REPLACEABLE_PLANT Lnet/minecraft/class_591;
+	FIELD field_2203 CHEESE Lnet/minecraft/class_591;
 	FIELD field_2204 WOOL Lnet/minecraft/class_591;
+	FIELD field_2205 FIRE Lnet/minecraft/class_591;
+	FIELD field_2206 NOTEBLOCK Lnet/minecraft/class_591;
 	FIELD field_2207 PART Lnet/minecraft/class_591;
+	FIELD field_2208 CARPET Lnet/minecraft/class_591;
 	FIELD field_2209 GLASS Lnet/minecraft/class_591;
+	FIELD field_2210 REDSTONE_LAMP Lnet/minecraft/class_591;
+	FIELD field_2211 TNT Lnet/minecraft/class_591;
+	FIELD field_2212 SWORD Lnet/minecraft/class_591;
+	FIELD field_2213 ICE Lnet/minecraft/class_591;
 	FIELD field_2214 PACKED_ICE Lnet/minecraft/class_591;
+	FIELD field_2215 SNOW_LAYER Lnet/minecraft/class_591;
 	FIELD field_2216 SNOW Lnet/minecraft/class_591;
 	METHOD <init> (Lnet/minecraft/class_592;)V
 		ARG 1 color
+	METHOD method_1804 requiresTool ()Lnet/minecraft/class_591;
 	METHOD method_1805 setFlammable ()Lnet/minecraft/class_591;
 	METHOD method_1806 isBurnable ()Z
 	METHOD method_1810 blocksMovement ()Z
+	METHOD method_1812 setTranslucent ()Lnet/minecraft/class_591;
+	METHOD method_1814 setAsGlassLike ()Lnet/minecraft/class_591;
 	METHOD method_1815 getColor ()Lnet/minecraft/class_592;
+	METHOD method_1816 requiresSilkTouch ()Lnet/minecraft/class_591;

--- a/mappings/net/minecraft/block/PortalMaterial.mapping
+++ b/mappings/net/minecraft/block/PortalMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_593 net/minecraft/block/PortalMaterial

--- a/mappings/net/minecraft/block/PressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/PressurePlateBlock.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_273 net/minecraft/block/PressurePlateBlock
 	FIELD field_1097 POWERED Lnet/minecraft/class_388;
 	CLASS class_274 ActivationRule
+		FIELD field_1100 ALL Lnet/minecraft/class_273$class_274;
+		FIELD field_1101 MOBS Lnet/minecraft/class_273$class_274;

--- a/mappings/net/minecraft/block/PrismarineBlock.mapping
+++ b/mappings/net/minecraft/block/PrismarineBlock.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_275 net/minecraft/block/PrismarineBlock
+	FIELD field_1103 BRICKS_ID I
+	FIELD field_1104 DARK_ID I
+	FIELD field_1105 VARIANT Lnet/minecraft/class_390;
+	FIELD field_1106 ROUGH_ID I
 	CLASS class_276 PrismarineType
 		FIELD field_1107 ROUGH Lnet/minecraft/class_275$class_276;
 		FIELD field_1108 BRICKS Lnet/minecraft/class_275$class_276;

--- a/mappings/net/minecraft/block/QuartzBlock.mapping
+++ b/mappings/net/minecraft/block/QuartzBlock.mapping
@@ -1,4 +1,20 @@
 CLASS net/minecraft/class_278 net/minecraft/block/QuartzBlock
 	FIELD field_1120 VARIANT Lnet/minecraft/class_390;
 	CLASS class_279 QuartzType
-		METHOD method_963 byId ()I
+		FIELD field_1122 DEFAULT Lnet/minecraft/class_278$class_279;
+		FIELD field_1123 CHISELED Lnet/minecraft/class_278$class_279;
+		FIELD field_1124 LINES_X Lnet/minecraft/class_278$class_279;
+		FIELD field_1125 LINES_Y Lnet/minecraft/class_278$class_279;
+		FIELD field_1126 LINES_Z Lnet/minecraft/class_278$class_279;
+		FIELD field_1127 TYPES [Lnet/minecraft/class_278$class_279;
+		FIELD field_1128 id I
+		FIELD field_1129 name Ljava/lang/String;
+		FIELD field_1130 stateName Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;)V
+			ARG 3 id
+			ARG 4 name
+			ARG 5 stateName
+		METHOD method_963 getId ()I
+		METHOD method_964 getById (I)Lnet/minecraft/class_278$class_279;
+			ARG 0 id
+		METHOD values ()[Lnet/minecraft/class_278$class_279;

--- a/mappings/net/minecraft/block/SandstoneBlock.mapping
+++ b/mappings/net/minecraft/block/SandstoneBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_296 net/minecraft/block/SandstoneBlock
+	FIELD field_1173 VARIANT Lnet/minecraft/class_390;
 	CLASS class_297 SanstoneType
 		FIELD field_1174 DEFAULT Lnet/minecraft/class_296$class_297;
 		FIELD field_1175 CHISELED Lnet/minecraft/class_296$class_297;

--- a/mappings/net/minecraft/block/StoneBrickBlock.mapping
+++ b/mappings/net/minecraft/block/StoneBrickBlock.mapping
@@ -1,5 +1,9 @@
 CLASS net/minecraft/class_317 net/minecraft/block/StoneBrickBlock
+	FIELD field_1232 MOSSY_ID I
+	FIELD field_1233 CRACKED_ID I
+	FIELD field_1234 CHISELED_ID I
 	FIELD field_1235 VARIANT Lnet/minecraft/class_390;
+	FIELD field_1236 DEFAULT_ID I
 	CLASS class_318 Type
 		FIELD field_1237 DEFAULT Lnet/minecraft/class_317$class_318;
 		FIELD field_1238 MOSSY Lnet/minecraft/class_317$class_318;
@@ -17,4 +21,3 @@ CLASS net/minecraft/class_317 net/minecraft/block/StoneBrickBlock
 		METHOD method_1023 getById (I)Lnet/minecraft/class_317$class_318;
 			ARG 0 id
 		METHOD method_1024 getValueName ()Ljava/lang/String;
-		METHOD values ()[Lnet/minecraft/class_317$class_318;

--- a/mappings/net/minecraft/block/entity/SpawnerBlockEntityBehavior.mapping
+++ b/mappings/net/minecraft/block/entity/SpawnerBlockEntityBehavior.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_88 net/minecraft/block/entity/SpawnerBlockEntityBehavior
+	FIELD field_199 defaultMob Ljava/lang/String;
+	METHOD method_181 (Lnet/minecraft/class_1405;)V
+		ARG 1 nbt

--- a/mappings/net/minecraft/class_133.mapping
+++ b/mappings/net/minecraft/class_133.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_133
-	METHOD <init> (ILnet/minecraft/class_113;)V
-		ARG 1 id

--- a/mappings/net/minecraft/class_1684.mapping
+++ b/mappings/net/minecraft/class_1684.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_1684
+	METHOD method_6373 ()Lcom/google/gson/JsonElement;
+	METHOD method_6374 (Lcom/google/gson/JsonElement;)V
+		ARG 1 jsonElement

--- a/mappings/net/minecraft/class_595.mapping
+++ b/mappings/net/minecraft/class_595.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_595
+	CLASS class_596
+		FIELD field_2258 COOL_WARM Lnet/minecraft/class_595$class_596;
+		FIELD field_2259 HEAT_ICE Lnet/minecraft/class_595$class_596;
+		FIELD field_2260 SPECIAL Lnet/minecraft/class_595$class_596;

--- a/mappings/net/minecraft/class_768.mapping
+++ b/mappings/net/minecraft/class_768.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_768
+	FIELD field_3301 ACHIEVEMENT_BACKGROUND Lnet/minecraft/class_1605;
+	FIELD field_3305 title Ljava/lang/String;
+	FIELD field_3306 name Ljava/lang/String;
+	FIELD field_3307 achievement Lnet/minecraft/class_1675;
+	FIELD field_3308 time J
+	METHOD <init> (Lnet/minecraft/class_669;)V
+		ARG 1 client
+	METHOD method_2853 (Lnet/minecraft/class_1675;)V
+		ARG 1 achieved
+	METHOD method_2855 (Lnet/minecraft/class_1675;)V
+		ARG 1 achieved

--- a/mappings/net/minecraft/client/gui/TwitchErrorScreen.mapping
+++ b/mappings/net/minecraft/client/gui/TwitchErrorScreen.mapping
@@ -1,0 +1,23 @@
+CLASS net/minecraft/class_827 net/minecraft/client/gui/TwitchErrorScreen
+	CLASS class_828 ErrorCause
+		FIELD field_3619 NO_FBO Lnet/minecraft/class_827$class_828;
+		FIELD field_3620 LIBRARY_ARCH_MISMATCH Lnet/minecraft/class_827$class_828;
+		FIELD field_3621 LIBRARY_FAILURE Lnet/minecraft/class_827$class_828;
+		FIELD field_3622 UNSUPPORTED_OS_WINDOWS Lnet/minecraft/class_827$class_828;
+		FIELD field_3623 UNSUPPORTED_OS_MAC Lnet/minecraft/class_827$class_828;
+		FIELD field_3624 UNSUPPORTED_OS_OTHER Lnet/minecraft/class_827$class_828;
+		FIELD field_3625 ACCOUNT_NOT_MIGRATED Lnet/minecraft/class_827$class_828;
+		FIELD field_3626 ACCOUNT_NOT_BOUND Lnet/minecraft/class_827$class_828;
+		FIELD field_3627 FAILED_TWITCH_AUTH Lnet/minecraft/class_827$class_828;
+		FIELD field_3628 FAILED_TWITCH_AUTH_ERROR Lnet/minecraft/class_827$class_828;
+		FIELD field_3629 INITIALIZATION_FAILURE Lnet/minecraft/class_827$class_828;
+		FIELD field_3630 UNKNOWN Lnet/minecraft/class_827$class_828;
+		FIELD field_3631 title Lnet/minecraft/class_1444;
+		FIELD field_3632 unavailable Lnet/minecraft/class_1444;
+		METHOD <init> (Ljava/lang/String;ILnet/minecraft/class_1444;)V
+			ARG 3 title
+		METHOD <init> (Ljava/lang/String;ILnet/minecraft/class_1444;Lnet/minecraft/class_1444;)V
+			ARG 3 title
+			ARG 4 unavailable
+		METHOD method_3020 getTitle ()Lnet/minecraft/class_1444;
+		METHOD method_3021 getUnavailableMessage ()Lnet/minecraft/class_1444;

--- a/mappings/net/minecraft/client/gui/screen/AchievementsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/AchievementsScreen.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_769 net/minecraft/client/gui/screen/AchievementsScreen
+	FIELD field_3313 ACHIEVEMENT_BACKGROUND Lnet/minecraft/class_1605;
+	FIELD field_3315 handler Lnet/minecraft/class_1688;
+	METHOD <init> (Lnet/minecraft/class_754;Lnet/minecraft/class_1688;)V
+		ARG 2 handler

--- a/mappings/net/minecraft/client/gui/screen/CommandBlockScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CommandBlockScreen.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_791 net/minecraft/client/gui/screen/CommandBlockScreen

--- a/mappings/net/minecraft/client/gui/screen/CustomizedWorldPresetsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CustomizedWorldPresetsScreen.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_732 net/minecraft/client/gui/screen/CustomizedWorldPresetsScreen
+	FIELD field_3105 title Ljava/lang/String;
+	FIELD field_3110 parent Lnet/minecraft/class_735;
+	METHOD <init> (Lnet/minecraft/class_735;)V
+		ARG 1 screen

--- a/mappings/net/minecraft/client/gui/screen/ResourcePackScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ResourcePackScreen.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_815 net/minecraft/client/gui/screen/ResourcePackScreen

--- a/mappings/net/minecraft/client/gui/screen/SnooperScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SnooperScreen.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_760 net/minecraft/client/gui/screen/SnooperScreen

--- a/mappings/net/minecraft/client/gui/screen/SoundsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SoundsScreen.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_762 net/minecraft/client/gui/screen/SoundsScreen
+	FIELD field_3253 name Ljava/lang/String;
+	FIELD field_3254 parent Lnet/minecraft/class_754;
+	FIELD field_3255 options Lnet/minecraft/class_671;
+	FIELD field_3256 off Ljava/lang/String;
+	METHOD <init> (Lnet/minecraft/class_754;Lnet/minecraft/class_671;)V
+		ARG 1 parent
+		ARG 2 options

--- a/mappings/net/minecraft/client/gui/screen/StreamIngestScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/StreamIngestScreen.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_822 net/minecraft/client/gui/screen/StreamIngestScreen

--- a/mappings/net/minecraft/client/gui/screen/StreamScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/StreamScreen.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_824 net/minecraft/client/gui/screen/StreamScreen
+	FIELD field_3587 STREAM_NUMERICAL_VALUES [Lnet/minecraft/class_671$class_672;
+	FIELD field_3588 STREAM_BOOLEAN_VALUES [Lnet/minecraft/class_671$class_672;
+	FIELD field_3589 parent Lnet/minecraft/class_754;
+	FIELD field_3590 options Lnet/minecraft/class_671;
+	METHOD <init> (Lnet/minecraft/class_754;Lnet/minecraft/class_671;)V
+		ARG 1 parent
+		ARG 2 options

--- a/mappings/net/minecraft/client/gui/screen/StreamUtilitiesScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/StreamUtilitiesScreen.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_829 net/minecraft/client/gui/screen/StreamUtilitiesScreen
+	FIELD field_3634 DARK_GREEN Lnet/minecraft/class_1;
+	FIELD field_3635 RED Lnet/minecraft/class_1;
+	FIELD field_3636 DARK_PURPLE Lnet/minecraft/class_1;

--- a/mappings/net/minecraft/client/gui/screen/ingame/VillagerTradingScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/VillagerTradingScreen.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/class_807 net/minecraft/client/gui/screen/ingame/VillagerTradingScreen
+	FIELD field_3513 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_3514 VILLAGER_SCREEN Lnet/minecraft/class_1605;
+	METHOD <init> (Lnet/minecraft/class_1962;Lnet/minecraft/class_83;Lnet/minecraft/class_99;)V
+		ARG 1 inventory
+		ARG 2 trader
+		ARG 3 world

--- a/mappings/net/minecraft/client/options/GameOptions.mapping
+++ b/mappings/net/minecraft/client/options/GameOptions.mapping
@@ -19,6 +19,7 @@ CLASS net/minecraft/class_671 net/minecraft/client/options/GameOptions
 	FIELD field_2642 streamPreferredServer Ljava/lang/String;
 	FIELD field_2643 streamChatEnabled I
 	FIELD field_2644 streamChatUserFilter I
+	FIELD field_2646 useNativeTransport Z
 	FIELD field_2649 keyForward Lnet/minecraft/class_666;
 	FIELD field_2650 keyLeft Lnet/minecraft/class_666;
 	FIELD field_2652 perspective I
@@ -33,6 +34,14 @@ CLASS net/minecraft/class_671 net/minecraft/client/options/GameOptions
 	FIELD field_2665 language Ljava/lang/String;
 	FIELD field_2667 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_2668 GSON Lcom/google/gson/Gson;
+	FIELD field_2670 GUI_SCALE [Ljava/lang/String;
+	FIELD field_2671 PARTICLES [Ljava/lang/String;
+	FIELD field_2672 AMBIENT_OCCLUSION [Ljava/lang/String;
+	FIELD field_2673 STREAM_COMPRESSION [Ljava/lang/String;
+	FIELD field_2674 STREAM_CHAT_ENABLED [Ljava/lang/String;
+	FIELD field_2675 STREAM_CHAT_USERFILTER [Ljava/lang/String;
+	FIELD field_2676 STREAM_MIC_TIGGLE [Ljava/lang/String;
+	FIELD field_2677 GRAPHICS_LEVEL [Ljava/lang/String;
 	FIELD field_2678 keyBack Lnet/minecraft/class_666;
 	FIELD field_2679 keyRight Lnet/minecraft/class_666;
 	FIELD field_2680 keyJump Lnet/minecraft/class_666;
@@ -60,6 +69,7 @@ CLASS net/minecraft/class_671 net/minecraft/client/options/GameOptions
 	FIELD field_2702 client Lnet/minecraft/class_669;
 	FIELD field_2703 difficulty Lnet/minecraft/class_1721;
 	FIELD field_2704 invertYMouse Z
+	FIELD field_2705 playerModelParts Ljava/util/Set;
 	FIELD field_2707 optionsFile Ljava/io/File;
 	FIELD field_2708 viewDistance I
 	FIELD field_2709 bobView Z
@@ -112,5 +122,74 @@ CLASS net/minecraft/class_671 net/minecraft/client/options/GameOptions
 	METHOD method_2352 getValueMessage (Lnet/minecraft/class_671$class_672;)Ljava/lang/String;
 		ARG 1 option
 	METHOD method_2353 getEnabledPlayerModelParts ()Ljava/util/Set;
+	METHOD method_2354 getCloudMode ()I
 	METHOD method_2355 shouldUseNativeTransport ()Z
+	CLASS 1
+		METHOD getActualTypeArguments ()[Ljava/lang/reflect/Type;
+		METHOD getOwnerType ()Ljava/lang/reflect/Type;
+		METHOD getRawType ()Ljava/lang/reflect/Type;
 	CLASS class_672 Option
+		FIELD field_2733 CHAT_WIDTH Lnet/minecraft/class_671$class_672;
+		FIELD field_2734 CHAT_HEIGHT_FOCUSED Lnet/minecraft/class_671$class_672;
+		FIELD field_2735 CHAT_HEIGHT_UNFOCUSED Lnet/minecraft/class_671$class_672;
+		FIELD field_2736 MIPMAP_LEVELS Lnet/minecraft/class_671$class_672;
+		FIELD field_2737 FORCE_UNICODE Lnet/minecraft/class_671$class_672;
+		FIELD field_2738 STREAM_BYTES_PER_PIXEL Lnet/minecraft/class_671$class_672;
+		FIELD field_2739 STREAM_VOLUME_MIC Lnet/minecraft/class_671$class_672;
+		FIELD field_2740 STREAM_VOLUME_SYSTEM Lnet/minecraft/class_671$class_672;
+		FIELD field_2741 STREAM_KBPS Lnet/minecraft/class_671$class_672;
+		FIELD field_2742 STREAM_FPS Lnet/minecraft/class_671$class_672;
+		FIELD field_2743 STREAM_COMPRESSION Lnet/minecraft/class_671$class_672;
+		FIELD field_2744 STREAM_SEND_METADATA Lnet/minecraft/class_671$class_672;
+		FIELD field_2745 STREAM_CHAT_ENABLED Lnet/minecraft/class_671$class_672;
+		FIELD field_2746 STREAM_CHAT_USER_FILTER Lnet/minecraft/class_671$class_672;
+		FIELD field_2747 STREAM_MIC_TOGGLE_BEHAVIOR Lnet/minecraft/class_671$class_672;
+		FIELD field_2748 BLOCK_ALTERNATIVES Lnet/minecraft/class_671$class_672;
+		FIELD field_2749 REDUCED_DEBUG_INFO Lnet/minecraft/class_671$class_672;
+		FIELD field_2750 ENTITY_SHADOWS Lnet/minecraft/class_671$class_672;
+		FIELD field_2751 REALMS_NOTIFICATIONS Lnet/minecraft/class_671$class_672;
+		FIELD field_2754 name Ljava/lang/String;
+		FIELD field_2755 increment F
+		FIELD field_2756 min F
+		FIELD field_2757 max F
+		FIELD field_2759 INVERT_MOUSE Lnet/minecraft/class_671$class_672;
+		FIELD field_2760 SENSITIVITY Lnet/minecraft/class_671$class_672;
+		FIELD field_2761 FIELD_OF_VIEW Lnet/minecraft/class_671$class_672;
+		FIELD field_2762 BRIGHTNESS Lnet/minecraft/class_671$class_672;
+		FIELD field_2763 SATURATION Lnet/minecraft/class_671$class_672;
+		FIELD field_2764 RENDER_DISTANCE Lnet/minecraft/class_671$class_672;
+		FIELD field_2765 VIEW_BOBBING Lnet/minecraft/class_671$class_672;
+		FIELD field_2766 ANAGLYPH Lnet/minecraft/class_671$class_672;
+		FIELD field_2767 MAX_FPS Lnet/minecraft/class_671$class_672;
+		FIELD field_2768 FBO_ENABLE Lnet/minecraft/class_671$class_672;
+		FIELD field_2769 SHOW_CLOUDS Lnet/minecraft/class_671$class_672;
+		FIELD field_2770 GRAPHICS Lnet/minecraft/class_671$class_672;
+		FIELD field_2771 AMBIENT_OCCLUSION Lnet/minecraft/class_671$class_672;
+		FIELD field_2772 GUI_SCALE Lnet/minecraft/class_671$class_672;
+		FIELD field_2773 PARTICLES Lnet/minecraft/class_671$class_672;
+		FIELD field_2774 CHAT_VISIBILITY Lnet/minecraft/class_671$class_672;
+		FIELD field_2775 CHAT_COLOR Lnet/minecraft/class_671$class_672;
+		FIELD field_2776 CHAT_LINKS Lnet/minecraft/class_671$class_672;
+		FIELD field_2777 CHAT_OPACITY Lnet/minecraft/class_671$class_672;
+		FIELD field_2778 CHAT_LINKS_PROMPT Lnet/minecraft/class_671$class_672;
+		FIELD field_2779 SNOOPER_ENABLED Lnet/minecraft/class_671$class_672;
+		FIELD field_2780 USE_FULLSCREEN Lnet/minecraft/class_671$class_672;
+		FIELD field_2781 ENABLE_VSYNC Lnet/minecraft/class_671$class_672;
+		FIELD field_2782 USE_VBO Lnet/minecraft/class_671$class_672;
+		FIELD field_2783 TOUCHSCREEN Lnet/minecraft/class_671$class_672;
+		FIELD field_2784 CHAT_SCALE Lnet/minecraft/class_671$class_672;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;ZZ)V
+			ARG 3 name
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;ZZFFF)V
+			ARG 3 name
+			ARG 6 min
+			ARG 7 max
+			ARG 8 increment
+		METHOD method_2357 setMaxValue (F)V
+			ARG 1 max
+		METHOD method_2358 (I)Lnet/minecraft/class_671$class_672;
+			ARG 0 id
+		METHOD method_2362 getOrdinal ()I
+		METHOD method_2364 getName ()Ljava/lang/String;
+		METHOD method_2367 getMaxValue ()F
+		METHOD values ()[Lnet/minecraft/class_671$class_672;

--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_91 net/minecraft/client/render/RenderLayer
+	FIELD field_218 SOLID Lnet/minecraft/class_91;
+	FIELD field_219 CUTOUT_MIPPED Lnet/minecraft/class_91;
+	FIELD field_220 CUTOUT Lnet/minecraft/class_91;
+	FIELD field_221 TRANSLUCENT Lnet/minecraft/class_91;
 	FIELD field_222 name Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 		ARG 3 name

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -12,7 +12,13 @@ CLASS net/minecraft/class_1036 net/minecraft/client/render/WorldRenderer
 	FIELD field_4420 lastCameraYaw D
 	FIELD field_4421 chunkBuilder Lnet/minecraft/class_1106;
 	FIELD field_4427 blockEntityCount I
+	FIELD field_4437 scheduleTerrainUpdate Z
 	FIELD field_4438 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_4439 MOON_PHASES Lnet/minecraft/class_1605;
+	FIELD field_4440 SUN Lnet/minecraft/class_1605;
+	FIELD field_4441 CLOUDS Lnet/minecraft/class_1605;
+	FIELD field_4442 END_SKY Lnet/minecraft/class_1605;
+	FIELD field_4443 FORCEFIELD Lnet/minecraft/class_1605;
 	FIELD field_4444 client Lnet/minecraft/class_669;
 	FIELD field_4445 textureManager Lnet/minecraft/class_1232;
 	FIELD field_4446 entityRenderDispatcher Lnet/minecraft/class_1135;

--- a/mappings/net/minecraft/client/sound/AbstractSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/AbstractSoundInstance.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1300 net/minecraft/client/sound/AbstractSoundInstance
+	FIELD field_5399 identifier Lnet/minecraft/class_1605;
 	FIELD field_5400 volume F
 	FIELD field_5401 pitch F
 	FIELD field_5402 x F
@@ -6,3 +7,6 @@ CLASS net/minecraft/class_1300 net/minecraft/client/sound/AbstractSoundInstance
 	FIELD field_5404 z F
 	FIELD field_5405 repeat Z
 	FIELD field_5406 repeatDelay I
+	FIELD field_5407 attenuationType Lnet/minecraft/class_1311$class_1312;
+	METHOD <init> (Lnet/minecraft/class_1605;)V
+		ARG 1 identifier

--- a/mappings/net/minecraft/client/sound/GuardianAttackSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/GuardianAttackSoundInstance.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1302 net/minecraft/client/sound/GuardianAttackSoundInstance

--- a/mappings/net/minecraft/client/sound/MinecartSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/MinecartSoundInstance.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_1304 net/minecraft/client/sound/MinecartSoundInstance
+	FIELD field_5412 player Lnet/minecraft/class_1963;
+	FIELD field_5413 minecart Lnet/minecraft/class_1895;
+	METHOD <init> (Lnet/minecraft/class_1963;Lnet/minecraft/class_1895;)V
+		ARG 1 player
+		ARG 2 minecart

--- a/mappings/net/minecraft/client/sound/SoundCategory.mapping
+++ b/mappings/net/minecraft/client/sound/SoundCategory.mapping
@@ -1,4 +1,13 @@
 CLASS net/minecraft/class_1306 net/minecraft/client/sound/SoundCategory
+	FIELD field_5414 MASTER Lnet/minecraft/class_1306;
+	FIELD field_5415 MUSIC Lnet/minecraft/class_1306;
+	FIELD field_5416 RECORDS Lnet/minecraft/class_1306;
+	FIELD field_5417 WEATHER Lnet/minecraft/class_1306;
+	FIELD field_5418 BLOCKS Lnet/minecraft/class_1306;
+	FIELD field_5419 MOBS Lnet/minecraft/class_1306;
+	FIELD field_5420 ANIMALS Lnet/minecraft/class_1306;
+	FIELD field_5421 PLAYERS Lnet/minecraft/class_1306;
+	FIELD field_5422 AMBIENT Lnet/minecraft/class_1306;
 	FIELD field_5423 NAME_MAP Ljava/util/Map;
 	FIELD field_5424 CATEGORY_MAP Ljava/util/Map;
 	FIELD field_5425 name Ljava/lang/String;
@@ -10,3 +19,4 @@ CLASS net/minecraft/class_1306 net/minecraft/client/sound/SoundCategory
 	METHOD method_4516 byName (Ljava/lang/String;)Lnet/minecraft/class_1306;
 		ARG 0 name
 	METHOD method_4517 getId ()I
+	METHOD values ()[Lnet/minecraft/class_1306;

--- a/mappings/net/minecraft/client/sound/SoundEntry.mapping
+++ b/mappings/net/minecraft/client/sound/SoundEntry.mapping
@@ -3,3 +3,7 @@ CLASS net/minecraft/class_1307 net/minecraft/client/sound/SoundEntry
 	FIELD field_5429 replace Z
 	METHOD method_4518 getSounds ()Ljava/util/List;
 	METHOD method_4521 canReplace ()Z
+	CLASS class_1308
+		CLASS class_1309 SoundEntryType
+			FIELD field_5437 FILE Lnet/minecraft/class_1307$class_1308$class_1309;
+			FIELD field_5438 SOUNDEVENT Lnet/minecraft/class_1307$class_1308$class_1309;

--- a/mappings/net/minecraft/client/sound/SoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/SoundInstance.mapping
@@ -1,11 +1,17 @@
 CLASS net/minecraft/class_1311 net/minecraft/client/sound/SoundInstance
-	METHOD method_4537 getId ()Lnet/minecraft/class_1605;
-	METHOD method_4545 getAttenuationType ()Lnet/minecraft/class_1311$class_1312;
-	METHOD method_4544 getZ ()F
-	METHOD method_4543 getY ()F
+	METHOD method_4537 getIdentifier ()Lnet/minecraft/class_1605;
+	METHOD method_4538 isRepeatable ()Z
 	METHOD method_4539 getRepeatDelay ()I
 	METHOD method_4540 getVolume ()F
 	METHOD method_4541 getPitch ()F
 	METHOD method_4542 getX ()F
-	METHOD method_4538 isRepeatable ()Z
+	METHOD method_4543 getY ()F
+	METHOD method_4544 getZ ()F
+	METHOD method_4545 getAttenuationType ()Lnet/minecraft/class_1311$class_1312;
 	CLASS class_1312 AttenuationType
+		FIELD field_5441 NONE Lnet/minecraft/class_1311$class_1312;
+		FIELD field_5442 LINEAR Lnet/minecraft/class_1311$class_1312;
+		FIELD field_5443 integer I
+		METHOD <init> (Ljava/lang/String;II)V
+			ARG 3 integer
+		METHOD method_4546 getInteger ()I

--- a/mappings/net/minecraft/client/sound/SoundManager.mapping
+++ b/mappings/net/minecraft/client/sound/SoundManager.mapping
@@ -27,6 +27,12 @@ CLASS net/minecraft/class_1328 net/minecraft/client/sound/SoundManager
 		ARG 2 entry
 	METHOD method_4613 stopAll ()V
 	METHOD method_4614 stop (Lnet/minecraft/class_1311;)V
+		ARG 1 instance
 	METHOD method_4615 isPlaying (Lnet/minecraft/class_1311;)Z
+		ARG 1 instance
 	METHOD method_4616 close ()V
 	METHOD method_4617 resumeAll ()V
+	CLASS 1
+		METHOD getActualTypeArguments ()[Ljava/lang/reflect/Type;
+		METHOD getOwnerType ()Ljava/lang/reflect/Type;
+		METHOD getRawType ()Ljava/lang/reflect/Type;

--- a/mappings/net/minecraft/client/sound/SoundRegistry.mapping
+++ b/mappings/net/minecraft/client/sound/SoundRegistry.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1330 net/minecraft/client/sound/SoundRegistry
 	FIELD field_5527 sounds Ljava/util/Map;
+	METHOD method_4619 clearRegistry ()V
 	METHOD method_4620 add (Lnet/minecraft/class_1327;)V
 		ARG 1 set

--- a/mappings/net/minecraft/client/sound/SoundSystem.mapping
+++ b/mappings/net/minecraft/client/sound/SoundSystem.mapping
@@ -18,6 +18,8 @@ CLASS net/minecraft/class_1325 net/minecraft/client/sound/SoundSystem
 	METHOD method_4580 play (Lnet/minecraft/class_1311;I)V
 		ARG 1 sound
 		ARG 2 delay
+	METHOD method_4587 (Lnet/minecraft/class_1963;F)V
+		ARG 1 player
 	METHOD method_4588 stop ()V
 	METHOD method_4589 stop (Lnet/minecraft/class_1311;)V
 	METHOD method_4591 stopAll ()V
@@ -26,3 +28,9 @@ CLASS net/minecraft/class_1325 net/minecraft/client/sound/SoundSystem
 	METHOD method_4594 pauseAll ()V
 	METHOD method_4595 resumeAll ()V
 	METHOD method_4598 start ()V
+	CLASS 2
+		METHOD openConnection (Ljava/net/URL;)Ljava/net/URLConnection;
+			ARG 1 url
+		CLASS 1
+			METHOD connect ()V
+			METHOD getInputStream ()Ljava/io/InputStream;

--- a/mappings/net/minecraft/client/sound/SoundSystem.mapping
+++ b/mappings/net/minecraft/client/sound/SoundSystem.mapping
@@ -1,10 +1,15 @@
 CLASS net/minecraft/class_1325 net/minecraft/client/sound/SoundSystem
 	FIELD field_5490 MARKER Lorg/apache/logging/log4j/Marker;
 	FIELD field_5491 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_5492 manager Lnet/minecraft/class_1328;
+	FIELD field_5493 options Lnet/minecraft/class_671;
 	FIELD field_5495 started Z
 	FIELD field_5496 ticks I
 	FIELD field_5499 sources Ljava/util/Map;
 	FIELD field_5502 startTicks Ljava/util/Map;
+	METHOD <init> (Lnet/minecraft/class_1328;Lnet/minecraft/class_671;)V
+		ARG 1 manager
+		ARG 2 options
 	METHOD method_4576 reloadSounds ()V
 	METHOD method_4577 getSoundVolume (Lnet/minecraft/class_1306;)F
 	METHOD method_4578 updateSoundVolume (Lnet/minecraft/class_1306;F)V

--- a/mappings/net/minecraft/client/texture/ClockSprite.mapping
+++ b/mappings/net/minecraft/client/texture/ClockSprite.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1237 net/minecraft/client/texture/ClockSprite

--- a/mappings/net/minecraft/client/texture/CompassSprite.mapping
+++ b/mappings/net/minecraft/client/texture/CompassSprite.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1238 net/minecraft/client/texture/CompassSprite

--- a/mappings/net/minecraft/enchantment/BetterLootEnchantment.mapping
+++ b/mappings/net/minecraft/enchantment/BetterLootEnchantment.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_76 net/minecraft/enchantment/BetterLootEnchantment

--- a/mappings/net/minecraft/enchantment/Enchantment.mapping
+++ b/mappings/net/minecraft/enchantment/Enchantment.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_64 net/minecraft/enchantment/Enchantment
 	FIELD field_115 translationKey Ljava/lang/String;
+	METHOD <init> (ILnet/minecraft/class_1605;ILnet/minecraft/class_65;)V
+		ARG 4 target
 	METHOD method_79 getTranslationKey ()Ljava/lang/String;
 	METHOD method_80 getMinimumPower (I)I
 		ARG 1 level
@@ -18,4 +20,5 @@ CLASS net/minecraft/class_64 net/minecraft/enchantment/Enchantment
 		ARG 1 level
 	METHOD method_91 byRawId (I)Lnet/minecraft/class_64;
 		ARG 0 id
+	METHOD method_92 setName (Ljava/lang/String;)Lnet/minecraft/class_64;
 	METHOD method_95 getMinimumLevel ()I

--- a/mappings/net/minecraft/enchantment/EnchantmentTarget.mapping
+++ b/mappings/net/minecraft/enchantment/EnchantmentTarget.mapping
@@ -10,3 +10,5 @@ CLASS net/minecraft/class_65 net/minecraft/enchantment/EnchantmentTarget
 	FIELD field_152 FISHING_ROD Lnet/minecraft/class_65;
 	FIELD field_153 BREAKABLE Lnet/minecraft/class_65;
 	FIELD field_154 BOW Lnet/minecraft/class_65;
+	METHOD method_96 isCompatible (Lnet/minecraft/class_2054;)Z
+		ARG 1 item

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -46,3 +46,7 @@ CLASS net/minecraft/class_1753 net/minecraft/entity/mob/MobEntity
 	METHOD method_7228 getMinAmbientSoundDelay ()I
 	METHOD method_7229 playAmbientSound ()V
 	METHOD method_7230 playSpawnEffects ()V
+	CLASS class_1754 Location
+		FIELD field_7510 ON_GROUND Lnet/minecraft/class_1753$class_1754;
+		FIELD field_7511 IN_AIR Lnet/minecraft/class_1753$class_1754;
+		FIELD field_7512 IN_WATER Lnet/minecraft/class_1753$class_1754;

--- a/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
@@ -37,10 +37,14 @@ CLASS net/minecraft/class_1895 net/minecraft/entity/vehicle/AbstractMinecartEnti
 		FIELD field_8157 SPAWNER Lnet/minecraft/class_1895$class_1896;
 		FIELD field_8158 HOPPER Lnet/minecraft/class_1895$class_1896;
 		FIELD field_8159 COMMAND_BLOCK Lnet/minecraft/class_1895$class_1896;
+		FIELD field_8160 TYPES Ljava/util/Map;
 		FIELD field_8161 id I
 		FIELD field_8162 name Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
 			ARG 3 id
 			ARG 4 name
 		METHOD method_7800 getId ()I
+		METHOD method_7801 getById (I)Lnet/minecraft/class_1895$class_1896;
+			ARG 0 id
 		METHOD method_7802 getName ()Ljava/lang/String;
+		METHOD values ()[Lnet/minecraft/class_1895$class_1896;

--- a/mappings/net/minecraft/recipe/ArmorRecipes.mapping
+++ b/mappings/net/minecraft/recipe/ArmorRecipes.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_36 net/minecraft/recipe/ArmorRecipes
+	FIELD field_86 pattern [[Ljava/lang/String;
+	FIELD field_87 items [[Lnet/minecraft/class_2054;
+	METHOD method_47 (Lnet/minecraft/class_49;)V
+		ARG 1 recipes

--- a/mappings/net/minecraft/recipe/BlockRecipes.mapping
+++ b/mappings/net/minecraft/recipe/BlockRecipes.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_53 net/minecraft/recipe/BlockRecipes
+	METHOD method_75 register (Lnet/minecraft/class_49;)V
+		ARG 1 recipes

--- a/mappings/net/minecraft/recipe/CombatItemRecipes.mapping
+++ b/mappings/net/minecraft/recipe/CombatItemRecipes.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_55 net/minecraft/recipe/CombatItemRecipes
+	FIELD field_105 pattern [[Ljava/lang/String;
+	FIELD field_106 items [[Ljava/lang/Object;
+	METHOD method_77 register (Lnet/minecraft/class_49;)V
+		ARG 1 recipes

--- a/mappings/net/minecraft/recipe/FoodRecipes.mapping
+++ b/mappings/net/minecraft/recipe/FoodRecipes.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_43 net/minecraft/recipe/FoodRecipes
+	METHOD method_51 register (Lnet/minecraft/class_49;)V
+		ARG 1 recipes

--- a/mappings/net/minecraft/recipe/HoeRecipes.mapping
+++ b/mappings/net/minecraft/recipe/HoeRecipes.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_54 net/minecraft/recipe/HoeRecipes
+	FIELD field_103 pattern [[Ljava/lang/String;
+	FIELD field_104 items [[Ljava/lang/Object;
+	METHOD method_76 register (Lnet/minecraft/class_49;)V
+		ARG 1 recipes

--- a/mappings/net/minecraft/recipe/NineGoldRecipes.mapping
+++ b/mappings/net/minecraft/recipe/NineGoldRecipes.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_47 net/minecraft/recipe/NineGoldRecipes
+	FIELD field_92 recipe [[Ljava/lang/Object;
+	METHOD method_60 register (Lnet/minecraft/class_49;)V
+		ARG 1 recipes

--- a/mappings/net/minecraft/recipe/Recipes.mapping
+++ b/mappings/net/minecraft/recipe/Recipes.mapping
@@ -3,4 +3,4 @@ CLASS net/minecraft/class_49 net/minecraft/recipe/Recipes
 	FIELD field_94 recipes Ljava/util/List;
 	METHOD method_66 getRecipes ()Lnet/minecraft/class_49;
 	METHOD method_69 register (Lnet/minecraft/class_2056;[Ljava/lang/Object;)Lnet/minecraft/class_51;
-	METHOD method_72 registerShapeless (Lnet/minecraft/class_2056;[Ljava/lang/Object;)V
+	METHOD method_72 registerShapelessRecipe (Lnet/minecraft/class_2056;[Ljava/lang/Object;)V

--- a/mappings/net/minecraft/recipe/ShapelessRecipes.mapping
+++ b/mappings/net/minecraft/recipe/ShapelessRecipes.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_41 net/minecraft/recipe/ShapelessRecipes
+	METHOD method_50 register (Lnet/minecraft/class_49;)V
+		ARG 1 recipes

--- a/mappings/net/minecraft/recipes/SmeltingRecipes.mapping
+++ b/mappings/net/minecraft/recipes/SmeltingRecipes.mapping
@@ -1,0 +1,24 @@
+CLASS net/minecraft/class_44 net/minecraft/recipes/SmeltingRecipes
+	FIELD field_89 INSTANCE Lnet/minecraft/class_44;
+	FIELD field_90 ORIGINAL_PRODUCT_MAP Ljava/util/Map;
+	FIELD field_91 PRODUCT_XP_MAP Ljava/util/Map;
+	METHOD method_52 getInstance ()Lnet/minecraft/class_44;
+	METHOD method_53 addBlock (Lnet/minecraft/class_160;Lnet/minecraft/class_2056;F)V
+		ARG 1 block
+		ARG 2 stack
+		ARG 3 xp
+	METHOD method_54 addItem (Lnet/minecraft/class_2054;Lnet/minecraft/class_2056;F)V
+		ARG 1 item
+		ARG 2 stack
+		ARG 3 xp
+	METHOD method_55 (Lnet/minecraft/class_2056;)Lnet/minecraft/class_2056;
+		ARG 1 stack
+	METHOD method_56 (Lnet/minecraft/class_2056;Lnet/minecraft/class_2056;)Z
+		ARG 1 stack1
+		ARG 2 stack2
+	METHOD method_57 addItemStack (Lnet/minecraft/class_2056;Lnet/minecraft/class_2056;F)V
+		ARG 1 original
+		ARG 2 product
+		ARG 3 xp
+	METHOD method_59 (Lnet/minecraft/class_2056;)F
+		ARG 1 stack

--- a/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
+++ b/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
@@ -7,7 +7,17 @@ CLASS net/minecraft/class_655 net/minecraft/scoreboard/AbstractTeam
 	METHOD method_2174 getNameTagVisibilityRule ()Lnet/minecraft/class_655$class_656;
 	METHOD method_2175 getDeathMessageVisibilityRule ()Lnet/minecraft/class_655$class_656;
 	CLASS class_656 VisibilityRule
+		FIELD field_2458 ALWAYS Lnet/minecraft/class_655$class_656;
+		FIELD field_2459 NEVER Lnet/minecraft/class_655$class_656;
+		FIELD field_2460 HIDE_FOR_OTHER_TEAMS Lnet/minecraft/class_655$class_656;
+		FIELD field_2461 HIDE_FOR_OWN_TEAM Lnet/minecraft/class_655$class_656;
 		FIELD field_2462 name Ljava/lang/String;
-		FIELD field_2463 value I
-		METHOD method_2177 getRule (Ljava/lang/String;)Lnet/minecraft/class_655$class_656;
+		FIELD field_2463 id I
+		FIELD field_2464 RULES Ljava/util/Map;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
+			ARG 3 name
+			ARG 4 id
+		METHOD method_2176 getValuesAsArray ()[Ljava/lang/String;
+		METHOD method_2177 getRuleByName (Ljava/lang/String;)Lnet/minecraft/class_655$class_656;
 			ARG 0 name
+		METHOD values ()[Lnet/minecraft/class_655$class_656;

--- a/mappings/net/minecraft/server/world/ServerWorldManager.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorldManager.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_1631 net/minecraft/server/world/ServerWorldManager
+	FIELD field_6593 server Lnet/minecraft/server/MinecraftServer;
+	FIELD field_6594 world Lnet/minecraft/class_1635;
+	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_1635;)V
+		ARG 1 server
+		ARG 2 world

--- a/mappings/net/minecraft/sound/GuardianAttackSoundInstance.mapping
+++ b/mappings/net/minecraft/sound/GuardianAttackSoundInstance.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_1302 net/minecraft/sound/GuardianAttackSoundInstance

--- a/mappings/net/minecraft/util/JsonElementProvider.mapping
+++ b/mappings/net/minecraft/util/JsonElementProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1684
+CLASS net/minecraft/class_1684 net/minecraft/util/JsonElementProvider
 	METHOD method_6373 ()Lcom/google/gson/JsonElement;
 	METHOD method_6374 (Lcom/google/gson/JsonElement;)V
 		ARG 1 jsonElement

--- a/mappings/net/minecraft/util/JsonSet.mapping
+++ b/mappings/net/minecraft/util/JsonSet.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_1689 net/minecraft/util/JsonSet
+	FIELD field_7026 set Ljava/util/Set;
+	METHOD delegate ()Ljava/lang/Object;

--- a/mappings/net/minecraft/util/Util.mapping
+++ b/mappings/net/minecraft/util/Util.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_1480 net/minecraft/util/Util
 	METHOD method_5419 getOperatingSystem ()Lnet/minecraft/class_1480$class_1481;
 	CLASS class_1481 OperatingSystem
+		FIELD field_6134 LINUX Lnet/minecraft/class_1480$class_1481;
+		FIELD field_6135 SOLARIS Lnet/minecraft/class_1480$class_1481;
+		FIELD field_6136 WINDOWS Lnet/minecraft/class_1480$class_1481;
+		FIELD field_6137 MACOS Lnet/minecraft/class_1480$class_1481;
+		FIELD field_6138 OTHER Lnet/minecraft/class_1480$class_1481;

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -1,22 +1,51 @@
 CLASS net/minecraft/class_646 net/minecraft/util/math/Box
-	FIELD field_2410 x2 D
-	FIELD field_2409 z1 D
-	FIELD field_2408 y1 D
 	FIELD field_2407 x1 D
-	FIELD field_2412 z2 D
+	FIELD field_2408 y1 D
+	FIELD field_2409 z1 D
+	FIELD field_2410 x2 D
 	FIELD field_2411 y2 D
+	FIELD field_2412 z2 D
+	METHOD <init> (DDDDDD)V
+		ARG 1 x1
+		ARG 3 y1
+		ARG 5 z1
+		ARG 7 x2
+		ARG 9 y2
+		ARG 11 z2
+	METHOD <init> (Lnet/minecraft/class_1372;Lnet/minecraft/class_1372;)V
+		ARG 1 pos1
+		ARG 2 pos2
+	METHOD method_2054 getAverage ()D
+	METHOD method_2055 incrementAll (DDD)Lnet/minecraft/class_646;
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_2056 createNewBox (DDDDDD)Lnet/minecraft/class_646;
+		ARG 0 x1
+		ARG 2 y1
+		ARG 4 z1
+		ARG 6 x2
+		ARG 8 y2
+		ARG 10 z2
+	METHOD method_2057 union (Lnet/minecraft/class_646;)Lnet/minecraft/class_646;
+		ARG 1 box
 	METHOD method_2059 contains (Lnet/minecraft/class_649;)Z
 		ARG 1 vec
+	METHOD method_2060 (Lnet/minecraft/class_649;Lnet/minecraft/class_649;)Lnet/minecraft/class_647;
+		ARG 1 vec1
+		ARG 2 vec2
+	METHOD method_2061 isInvalid ()Z
 	METHOD method_2062 expand (DDD)Lnet/minecraft/class_646;
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_2061 isValid ()Z
+	METHOD method_2063 intersects (Lnet/minecraft/class_646;)Z
+		ARG 1 box
 	METHOD method_2066 offset (DDD)Lnet/minecraft/class_646;
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_2057 union (Lnet/minecraft/class_646;)Lnet/minecraft/class_646;
-		ARG 1 box
-	METHOD method_2063 intersects (Lnet/minecraft/class_646;)Z
-		ARG 1 box
+	METHOD method_2069 increment (DDD)Lnet/minecraft/class_646;
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z

--- a/mappings/net/minecraft/util/math/Vec3i.mapping
+++ b/mappings/net/minecraft/util/math/Vec3i.mapping
@@ -2,10 +2,18 @@ CLASS net/minecraft/class_1400 net/minecraft/util/math/Vec3i
 	FIELD field_5895 x I
 	FIELD field_5897 y I
 	FIELD field_5898 z I
+	METHOD <init> (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
 	METHOD <init> (III)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+	METHOD compareTo (Ljava/lang/Object;)I
+		ARG 1 vec
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 object
 	METHOD method_4975 crossProduct (Lnet/minecraft/class_1400;)Lnet/minecraft/class_1400;
 		ARG 1 vec
 	METHOD method_4977 getSquaredDistance (Lnet/minecraft/class_1400;)D

--- a/mappings/net/minecraft/util/snooper/Snoopable.mapping
+++ b/mappings/net/minecraft/util/snooper/Snoopable.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1729 net/minecraft/util/snooper/Snoopable
 	METHOD method_6794 addSnooperInfo (Lnet/minecraft/class_1728;)V
+		ARG 1 snooper
 	METHOD method_6795 isSnooperEnabled ()Z
 	METHOD method_6796 (Lnet/minecraft/class_1728;)V
 		ARG 1 snooper

--- a/mappings/net/minecraft/world/biome/EndBiomePopulator.mapping
+++ b/mappings/net/minecraft/world/biome/EndBiomePopulator.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_143 net/minecraft/world/biome/EndBiomePopulator

--- a/mappings/net/minecraft/world/biome/MutatedBiome.mapping
+++ b/mappings/net/minecraft/world/biome/MutatedBiome.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_133 net/minecraft/world/biome/MutatedBiome
+	FIELD field_526 original Lnet/minecraft/class_113;
+	METHOD <init> (ILnet/minecraft/class_113;)V
+		ARG 1 id
+		ARG 2 original

--- a/mappings/net/minecraft/world/biome/SavannaBiome.mapping
+++ b/mappings/net/minecraft/world/biome/SavannaBiome.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_137 net/minecraft/world/biome/SavannaBiome
+	CLASS class_138 ShatteredSavannaBiome

--- a/mappings/net/minecraft/world/gen/feature/FillerBlockFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/FillerBlockFeature.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_465 net/minecraft/world/gen/feature/FillerBlockFeature
+	FIELD field_1955 block Lnet/minecraft/class_160;
+	METHOD <init> (Lnet/minecraft/class_160;)V
+		ARG 1 block


### PR DESCRIPTION
Recipe registering classes were pretty easy to map as they were all kinda the same. The material fields were mapped with a simple ctrl + c, which I expect should have been done for other material fields.
*please don't squash merge because it makes collaborating much harder*

Closes #34 
Closes #35 
Closes #36 

Changelog:-
```applescript
 Changes to be committed:
	modified:   mappings/net/minecraft/client/options/GameOptions.mapping
	modified:   mappings/net/minecraft/client/render/WorldRenderer.mapping
	modified:   mappings/net/minecraft/client/sound/AbstractSoundInstance.mapping
	new file:   mappings/net/minecraft/client/sound/GuardianAttackSoundInstance.mapping
	modified:   mappings/net/minecraft/client/sound/MinecartSoundInstance.mapping
	modified:   mappings/net/minecraft/client/sound/SoundCategory.mapping
	modified:   mappings/net/minecraft/client/sound/SoundEntry.mapping
	modified:   mappings/net/minecraft/client/sound/SoundInstance.mapping
	modified:   mappings/net/minecraft/client/sound/SoundManager.mapping
	modified:   mappings/net/minecraft/client/sound/SoundRegistry.mapping
	modified:   mappings/net/minecraft/client/sound/SoundSystem.mapping
	new file:   mappings/net/minecraft/server/world/ServerWorldManager.mapping
	deleted:    mappings/net/minecraft/sound/GuardianAttackSoundInstance.mapping
	modified:   mappings/net/minecraft/util/math/Vec3i.mapping
	new file:   mappings/net/minecraft/class_768.mapping
	new file:   mappings/net/minecraft/client/gui/TwitchErrorScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/AchievementsScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/CommandBlockScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/CustomizedWorldPresetsScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/ResourcePackScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/SnooperScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/SoundsScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/StreamIngestScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/StreamScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/StreamUtilitiesScreen.mapping
	new file:   mappings/net/minecraft/client/gui/screen/ingame/VillagerTradingScreen.mapping
	modified:   mappings/net/minecraft/client/sound/SoundSystem.mapping
	new file:   mappings/net/minecraft/client/texture/ClockSprite.mapping
	new file:   mappings/net/minecraft/client/texture/CompassSprite.mapping
	modified:   mappings/net/minecraft/scoreboard/AbstractTeam.mapping
	modified:   mappings/net/minecraft/util/Util.mapping
	modified:   mappings/net/minecraft/util/math/Box.mapping
	modified:   mappings/net/minecraft/util/snooper/Snoopable.mapping
	modified:   mappings/net/minecraft/block/BedBlock.mapping
	modified:   mappings/net/minecraft/block/BigMushroomBlock.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/block/Blocks.mapping
	modified:   mappings/net/minecraft/block/CakeBlock.mapping
	modified:   mappings/net/minecraft/block/PressurePlateBlock.mapping
	modified:   mappings/net/minecraft/block/SandstoneBlock.mapping
	modified:   mappings/net/minecraft/block/Material.mapping
	new file:   mappings/net/minecraft/block/PortalMaterial.mapping
	modified:   mappings/net/minecraft/client/render/RenderLayer.mapping
	modified:   mappings/net/minecraft/block/PrismarineBlock.mapping
	modified:   mappings/net/minecraft/block/QuartzBlock.mapping
	modified:   mappings/net/minecraft/block/StoneBrickBlock.mapping
	new file:   mappings/net/minecraft/block/entity/SpawnerBlockEntityBehavior.mapping
	new file:   mappings/net/minecraft/class_1684.mapping
	new file:   mappings/net/minecraft/enchantment/BetterLootEnchantment.mapping
	modified:   mappings/net/minecraft/enchantment/Enchantment.mapping
	modified:   mappings/net/minecraft/enchantment/EnchantmentTarget.mapping
	modified:   mappings/net/minecraft/entity/mob/MobEntity.mapping
	modified:   mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
	new file:   mappings/net/minecraft/recipe/ArmorRecipes.mapping
	new file:   mappings/net/minecraft/recipe/BlockRecipes.mapping
	new file:   mappings/net/minecraft/recipe/CombatItemRecipes.mapping
	new file:   mappings/net/minecraft/recipe/FoodRecipes.mapping
	new file:   mappings/net/minecraft/recipe/HoeRecipes.mapping
	new file:   mappings/net/minecraft/recipe/NineGoldRecipes.mapping
	modified:   mappings/net/minecraft/recipe/Recipes.mapping
	new file:   mappings/net/minecraft/recipe/ShapelessRecipes.mapping
	new file:   mappings/net/minecraft/recipes/SmeltingRecipes.mapping
	modified:   mappings/net/minecraft/util/JsonSet.mapping
	renamed:    mappings/net/minecraft/class_1684.mapping -> mappings/net/minecraft/util/JsonElementProvider.mapping
	deleted:    mappings/net/minecraft/class_133.mapping
	new file:   mappings/net/minecraft/class_595.mapping
	new file:   mappings/net/minecraft/world/biome/EndBiomePopulator.mapping
	new file:   mappings/net/minecraft/world/biome/MutatedBiome.mapping
	modified:   mappings/net/minecraft/world/biome/SavannaBiome.mapping
	new file:   mappings/net/minecraft/world/gen/feature/FillerBlockFeature.mapping
```

