### PR TITLE
Add three issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
+++ b/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
@@ -18,6 +18,3 @@ Describe what the element does
 
 **Expected name**  
 The expected name
-
-**Do you agree to the note given in CONTRIBUTING.md**  
-No / Yes

--- a/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
+++ b/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
@@ -1,0 +1,23 @@
+---
+name: Incorrect mapping name
+about: Report a mapping name which you might think is incorrect
+title: 
+labels: bug
+assignees: ''
+
+---
+
+**Type**  
+Class / Field / Method / Parameter
+
+**Describe where the element is**  
+State the affected element's type descriptor or describe where it is
+
+**Description of the element**  
+Describe what the element does
+
+**Expected name**  
+The expected name
+
+**Do you agree to the note given in CONTRIBUTING.md**  
+No / Yes

--- a/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
+++ b/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
@@ -18,3 +18,6 @@ Describe what the element does
 
 **Expected name**  
 The expected name
+
+**Additional Context**
+Any additional information

--- a/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
+++ b/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md
@@ -1,6 +1,6 @@
 ---
 name: Incorrect mapping name
-about: Report a mapping name which you might think is incorrect
+about: Report an incorrect mapping name
 title: 
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/suggestion
+++ b/.github/ISSUE_TEMPLATE/suggestion
@@ -1,0 +1,11 @@
+---
+name: Suggestion
+about: Suggest classes that should be mapped or documented
+title: 
+labels: bug
+assignees: ''
+
+---
+
+**Name of the classes**  
+Class1, Class2

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,11 +1,14 @@
 ---
 name: Suggestion
 about: Suggest classes that should be mapped or documented
-title:.
+title:
 labels: bug
 assignees: ''
 
 ---
 
-**Name of the classes**  
+**Names of the classes**  
 Class1, Class2
+
+**Additional Context**
+Any Additional information

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,7 +1,7 @@
 ---
 name: Suggestion
 about: Suggest classes that should be mapped or documented
-title: 
+title:.
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -2,7 +2,7 @@
 name: Suggestion
 about: Suggest classes that should be mapped or documented
 title:
-labels: bug
+labels: enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/visibility-issue.md
+++ b/.github/ISSUE_TEMPLATE/visibility-issue.md
@@ -1,0 +1,20 @@
+---
+name: Class visibility issue
+about: Report an incorrect package name
+title: 
+labels: bug
+assignees: ''
+
+---
+
+**Name of the class**  
+Classname
+
+**Affected Classes**  
+Class1, Class2
+
+**Description of the class**  
+Describe what the class does
+
+**Additional context**  
+Any Additional context or screenshots


### PR DESCRIPTION
### Issue Templates
* Incorrect mapping name
* Class Visibility
* Suggestion
and no blank issues unless we could possibly have any issues other than these. 
the issue templates come from [here](https://github.com/Useless-Minecraft-Stuff/LegacyMappings/blob/master/.github/ISSUE_TEMPLATE/incorrect-mapping-name.md)
 
Closes #38 
Closes #44 

*please squash merge this because nine of the ten of the commits were done on GitHub*