### PR TITLE
Most missing methods and parameters, and javadoc for the Block class

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -29,7 +29,7 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		COMMENT Used By Ice and Packed Ice
 	FIELD field_588 stateManager Lnet/minecraft/class_378;
 		COMMENT Stores the block's state manager
-	FIELD field_589 blockState Lnet/minecraft/class_376;
+	FIELD field_589 defaultState Lnet/minecraft/class_376;
 		COMMENT Stores the block's default state
 	FIELD field_590 translationKey Ljava/lang/String;
 		COMMENT Stores the block's translation key
@@ -124,11 +124,25 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		COMMENT Disables tracking by stats for the current block. Used in registering blocks.
 		COMMENT @return The current block
 	METHOD method_626 getItemGroup ()Lnet/minecraft/class_2029;
+		COMMENT Returns the block's ItemGroup.
+		COMMENT Only called on the client.
+		COMMENT @return The Block's item group
 	METHOD method_629 hasComparatorOutput ()Z
+		COMMENT Returns whether the block provides comparator output.
+		COMMENT Used in blocks with entities like Chests and Droppers.
+		COMMENT @return Whether the block provides comparator output
 	METHOD method_630 getStateManager ()Lnet/minecraft/class_378;
+		COMMENT Returns the current state manager.
+		COMMENT @return The current state manager
 	METHOD method_631 getDefaultState ()Lnet/minecraft/class_376;
+		COMMENT Returns the block's default BlockState.
+		COMMENT @return The block's default BlockState
 	METHOD method_632 getOffsetType ()Lnet/minecraft/class_160$class_161;
+		COMMENT Returns the block's offset type.
+		COMMENT Used by grass and flowers.
+		COMMENT @return The block's offset type
 	METHOD method_633 setup ()V
+		COMMENT Registers all blocks
 	METHOD method_634 getTranslationKey ()Ljava/lang/String;
 		COMMENT Returns the block's translation key
 		COMMENT @return Translation Key
@@ -157,9 +171,13 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 data
 			COMMENT The Blockstate's associated data value
 	METHOD method_638 register (ILjava/lang/String;Lnet/minecraft/class_160;)V
+		COMMENT Registers a block to the registry
 		ARG 0 id
+			COMMENT The block's Id
 		ARG 1 name
+			COMMENT The block's name
 		ARG 2 block
+			COMMENT The block object
 	METHOD method_639 getBonusDrops (ILjava/util/Random;)I
 		COMMENT Returns the number bonus drops for a block when broken.
 		COMMENT @return Bonus drops for a block
@@ -168,11 +186,18 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 rand
 			COMMENT Random object
 	METHOD method_640 register (ILnet/minecraft/class_1605;Lnet/minecraft/class_160;)V
+		COMMENT Registers a block to the registry
 		ARG 0 id
+			COMMENT The block's Id
 		ARG 1 identifier
+			COMMENT The block's Identifier
 		ARG 2 block
+			COMMENT The block object
 	METHOD method_641 shouldDropItemsOnExplosion (Lnet/minecraft/class_93;)Z
+		COMMENT Returns whether the block should drop as an Item during an explosion.
+		COMMENT @return Whether the block should drop as an item during an explosion
 		ARG 1 explosion
+			COMMENT The explosion that caused the block to break
 	METHOD method_642 getTickRate (Lnet/minecraft/class_99;)I
 		COMMENT Returns the block's tick rate.
 		COMMENT Default is 10.
@@ -263,11 +288,16 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 			COMMENT The entity who placed the block
 		ARG 5 itemStack
 			COMMENT ItemStack instance
-	METHOD method_653 onBreak (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1963;)V
+	METHOD method_653 onBreakByPlayer (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1963;)V
+		COMMENT Runs when the block is broken by a player.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 player
+			COMMENT The player who broke the block
 	METHOD method_654 onUse (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1963;Lnet/minecraft/class_1383;FFF)Z
 		COMMENT Runs when the block is <i>used</i>, i.e. right clicked in most cases.
 		COMMENT It is similar to the same method in Item, but this method is called only when the player uses it when the block is placed, not when the player is holding the BlockItem.
@@ -401,6 +431,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 0 block
 			COMMENT The block for which the id is returned
 	METHOD method_671 areBlocksEqual (Lnet/minecraft/class_160;Lnet/minecraft/class_160;)Z
+		COMMENT Returns whether two blocks are equal.
+		COMMENT @return Whether two blocks are equal
 		ARG 0 one
 		ARG 1 two
 	METHOD method_672 getMeta (Lnet/minecraft/class_376;)I
@@ -455,16 +487,24 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 pos
 			COMMENT The block's position
 	METHOD method_680 setItemGroup (Lnet/minecraft/class_2029;)Lnet/minecraft/class_160;
+		COMMENT Sets the block's ItemGroup. Used in registering blocks.
+		COMMENT @return The current block
 		ARG 1 group
+			COMMENT The itemgroup that the block must be added to
 	METHOD method_681 getBlockFromItem (Lnet/minecraft/class_2054;)Lnet/minecraft/class_160;
 		COMMENT Returns a block by converting a blockitem to a block
 		COMMENT @return The block
 		ARG 0 item
 			COMMENT The item that must be converted to a block
 	METHOD method_682 appendStacks (Lnet/minecraft/class_2054;Lnet/minecraft/class_2029;Ljava/util/List;)V
+		COMMENT Appends ItemStacks to an itemgroup.
+		COMMENT Only called on the client.
 		ARG 1 item
+			COMMENT The Item that must be added
 		ARG 2 group
+			COMMENT The ItemGroup that the item must be added to
 		ARG 3 stacks
+			COMMENT The list of currently added ItemStacks to the ItemGroup
 	METHOD method_683 setTickRandomly (Z)Lnet/minecraft/class_160;
 		COMMENT Sets whether the current block has random ticks. Used in registering blocks.
 		COMMENT @return The current block
@@ -540,7 +580,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 4 facing
 			COMMENT The block's direction
 	METHOD method_695 isEqualTo (Lnet/minecraft/class_160;)Z
+		COMMENT Returns whether the current block and another block are equal
+		COMMENT @return Whether the current block and the other block are equal
 		ARG 1 block
+			COMMENT The other block
 	METHOD method_697 (Lnet/minecraft/class_649;)Z
 		ARG 1 vec
 	METHOD method_698 get (Ljava/lang/String;)Lnet/minecraft/class_160;
@@ -559,6 +602,9 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 0 id
 			COMMENT The id for which the Block is returned
 	METHOD method_702 getPickItem (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Lnet/minecraft/class_2054;
+		COMMENT Called when a player presses the pick block key while facing the block.
+		COMMENT It returns the item that must be placed into the player's inventory.
+		COMMENT @return The Item that must be placed into the player's inventory
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_703 onCreation (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
@@ -614,6 +660,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 state
 			COMMENT The block's BlockState
 	METHOD method_714 appendProperties ()Lnet/minecraft/class_378;
+		COMMENT Returns a new state manager with a property array.
+		COMMENT @return New state manager
 	METHOD method_715 setOpacity (I)Lnet/minecraft/class_160;
 		COMMENT Sets the block's light opacity. Used in registering blocks.
 		COMMENT @return The current block
@@ -662,17 +710,30 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_725 setBlockItemBounds ()V
 		COMMENT Sets the bounds for the BlockItem
 	METHOD method_726 getMeta (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)I
+		COMMENT Returns metadata from a world and a BlockPos
+		COMMENT @return Metadata
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 	METHOD method_727 setDefaultState (Lnet/minecraft/class_376;)V
+		COMMENT Sets the block's default BlockState.
 		ARG 1 state
+			COMMENT The default state
 	METHOD method_728 getPistonInteractionType ()I
 		COMMENT Returns the block's piston interaction type, as provided by it's material.
 		COMMENT @return Current block's piston interaction type
 	METHOD method_729 rainTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)V
+		COMMENT Runs every tick when raining.
+		COMMENT Used my cauldrons to randomly fill up when raining.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 	METHOD method_730 getComparatorOutput (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)I
+		COMMENT Returns the block's comparator output value.
+		COMMENT Used in blocks with entities like Chests and Droppers.
+		COMMENT @return The block's comparator output value
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_731 getRenderLayerType ()Lnet/minecraft/class_91;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -97,14 +97,32 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		COMMENT Returns whether a block has collision, i.e. stops entities
 		COMMENT @return Whether a block has collision
 	METHOD method_616 getMinX ()D
+		COMMENT Returns the block's bounding box' minimum X value
+		COMMENT @return Minimum X value
 	METHOD method_617 getMaxX ()D
+		COMMENT Returns the block's bounding box' minimum Y value
+		COMMENT @return Minimum Y value
 	METHOD method_618 getMinY ()D
+		COMMENT Returns the block's bounding box' minimum Z value
+		COMMENT @return Minimum Z value
 	METHOD method_619 getMaxY ()D
+		COMMENT Returns the block's bounding box' maximum X value
+		COMMENT @return Maximum X value
 	METHOD method_620 getMinZ ()D
+		COMMENT Returns the block's bounding box' maximum Y value
+		COMMENT @return Maximum Y value
 	METHOD method_621 getMaxZ ()D
+		COMMENT Returns the block's bounding box' maximum Z value
+		COMMENT @return Maximum Z value
 	METHOD method_623 canSilkTouchHarvest ()Z
+		COMMENT Returns whether the block can be harvested using Silk Touch.
+		COMMENT @return Whether the block can be harvested using Silk Touch
 	METHOD method_624 hasStats ()Z
+		COMMENT Returns whether the current block should be tracked for stats
+		COMMENT @return Whether the current block should be tracked for stats
 	METHOD method_625 disableStats ()Lnet/minecraft/class_160;
+		COMMENT Disables tracking by stats for the current block. Used in registering blocks.
+		COMMENT @return The current block
 	METHOD method_626 getItemGroup ()Lnet/minecraft/class_2029;
 	METHOD method_629 hasComparatorOutput ()Z
 	METHOD method_630 getStateManager ()Lnet/minecraft/class_378;
@@ -112,6 +130,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_632 getOffsetType ()Lnet/minecraft/class_160$class_161;
 	METHOD method_633 setup ()V
 	METHOD method_634 getTranslationKey ()Ljava/lang/String;
+		COMMENT Returns the block's translation key
+		COMMENT @return Translation Key
 	METHOD method_635 setLightLevel (F)Lnet/minecraft/class_160;
 		COMMENT Sets the block's luminescence. Used in registering blocks.
 		COMMENT @return The current block
@@ -141,8 +161,12 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 name
 		ARG 2 block
 	METHOD method_639 getBonusDrops (ILjava/util/Random;)I
+		COMMENT Returns the number bonus drops for a block when broken.
+		COMMENT @return Bonus drops for a block
 		ARG 1 id
+			COMMENT Id
 		ARG 2 rand
+			COMMENT Random object
 	METHOD method_640 register (ILnet/minecraft/class_1605;Lnet/minecraft/class_160;)V
 		ARG 0 id
 		ARG 1 identifier
@@ -184,11 +208,18 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 5 id
 			COMMENT Id
 	METHOD method_647 onEvent (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;II)Z
+		COMMENT Runs when an event takes place
+		COMMENT @return Whether the event is successful
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 id
+			COMMENT Id
 		ARG 5 meta
+			COMMENT Metadata
 	METHOD method_648 neighborUpdate (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_160;)V
 		COMMENT Runs when its adjacent blocks are updated.
 		COMMENT It will also run when the block is placed or removed as Air is being updated.
@@ -211,81 +242,145 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 4 rand
 			COMMENT Random object
 	METHOD method_651 onEntityCollision (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1745;)V
+		COMMENT Runs every time an entity collides with the block
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 entity
+			COMMENT The entity that collided with the block
 	METHOD method_652 onPlaced (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1752;Lnet/minecraft/class_2056;)V
+		COMMENT Runs when the block is placed by an entity
 		ARG 1 world
+			COMMENT The world that the block is in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 placer
+			COMMENT The entity who placed the block
 		ARG 5 itemStack
+			COMMENT ItemStack instance
 	METHOD method_653 onBreak (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1963;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
 		ARG 4 player
 	METHOD method_654 onUse (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1963;Lnet/minecraft/class_1383;FFF)Z
+		COMMENT Runs when the block is <i>used</i>, i.e. right clicked in most cases.
+		COMMENT It is similar to the same method in Item, but this method is called only when the player uses it when the block is placed, not when the player is holding the BlockItem.
+		COMMENT @return Whether the action is succesful
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
-		ARG 4 rplayer
+			COMMENT The block's BlockState
+		ARG 4 player
+			COMMENT The player who <i>used</i> the block
 		ARG 5 direction
+			COMMENT The direction that the block is facing
 	METHOD method_655 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_649;Lnet/minecraft/class_649;)Lnet/minecraft/class_647;
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 vec1
 		ARG 4 vec2
 	METHOD method_656 getStateFromData (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;FFFILnet/minecraft/class_1752;)Lnet/minecraft/class_376;
+		COMMENT Returns a BlockState from an id
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 dir
+			COMMENT The block's direction
 		ARG 7 id
 		ARG 8 entity
 	METHOD method_657 canBeReplaced (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;Lnet/minecraft/class_2056;)Z
+		COMMENT Returns whether the current block can be replaced.
+		COMMENT Useful for grass like blocks.
+		COMMENT @return Whether the current block can be replaced
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 dir
+			COMMENT The block's direction
 		ARG 4 stack
+			COMMENT ItemStack
 	METHOD method_658 onSteppedOn (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1745;)V
+		COMMENT Runs every time an entity steps on the Block.
+		COMMENT Used by redstone ore to change it's state.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 entity
+			COMMENT The entity who stepped on the block
 	METHOD method_659 onLandedUpon (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1745;F)V
+		COMMENT Runs when an entity falls on the block.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 entity
+			COMMENT The entity who fell on the block
 		ARG 4 distance
+			COMMENT The relative height from which the entity fell
 	METHOD method_661 onBlockBreakStart (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1963;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 player
 	METHOD method_662 onBlockBreak (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_2056;)V
+		COMMENT Runs when a block is broken
 		ARG 0 world
+			COMMENT The world that the block is placed in
 		ARG 1 pos
+			COMMENT The block's position
 		ARG 2 item
+			COMMENT Allows creating an ItemEntity
 	METHOD method_663 setEntityVelocity (Lnet/minecraft/class_99;Lnet/minecraft/class_1745;)V
+		COMMENT Sets the speed of an entity moving on the block
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 entity
+			COMMENT The entity that the speed must be changed for
 	METHOD method_664 harvest (Lnet/minecraft/class_99;Lnet/minecraft/class_1963;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_348;)V
+		COMMENT Runs every time a player begins to break the block.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 player
+			COMMENT The player who is mining the block
 		ARG 3 pos
+			COMMENT The block's position
 		ARG 4 state
+			COMMENT The block's BlockState
 		ARG 5 be
+			COMMENT The block entity in the block
 	METHOD method_665 getOutlineShape (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)V
 		ARG 1 view
 		ARG 2 pos
 	METHOD method_666 getBlockColor (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;I)I
+		COMMENT Returns the current block's color
+		COMMENT @return Block color
 		ARG 1 view
+			COMMENT WorldView instance
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 id
+			COMMENT Id
 	METHOD method_667 getWeakRedstonePower (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1383;)I
+		COMMENT Returns the block's weak redstone power.
+		COMMENT @return Block's weak redstone power
 		ARG 1 view
+			COMMENT WorldView instance
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 facing
+			COMMENT The block's direction
 	METHOD method_668 isSideInvisible (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;)Z
 		COMMENT Returns whether the current block has connected sides, i.e its side faces are invisible when covered by other blocks. Used by glass to prevent the white dots from appearing everywhere through adjacent glass blocks.
 		COMMENT @return Whether the current block has connected sides
@@ -309,7 +404,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 0 one
 		ARG 1 two
 	METHOD method_672 getMeta (Lnet/minecraft/class_376;)I
+		COMMENT Returns the metadata value for a certain BlockState
+		COMMENT @return Metadata value
 		ARG 1 state
+			COMMENT The BlockState
 	METHOD method_673 getBlockState (Lnet/minecraft/class_376;Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)Lnet/minecraft/class_376;
 		COMMENT Returns the current block's blockstate at a certain position
 		COMMENT @return state
@@ -342,7 +440,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 rand
 			COMMENT Random object
 	METHOD method_678 getBlastResistance (Lnet/minecraft/class_1745;)F
+		COMMENT Returns the block's blast resistance as per the entity provided.
+		COMMENT @return Blast Resistance
 		ARG 1 entity
+			COMMENT The entity that blast resistance must be calculated for
 	METHOD method_679 calcBlockBreakingData (Lnet/minecraft/class_1963;Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
 		COMMENT Calculates how fast or slow the block must be broken by a Player.
 		COMMENT  Status effects such as Haste and Mining fatigue are taken into consideration.
@@ -378,9 +479,14 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_687 dropExperience (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;I)V
+		COMMENT Runs when the block is broken to drop experience.
+		COMMENT Since entities are being spawned, most of it only happens on a ServerWorld.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 size
+			COMMENT Size
 	METHOD method_688 onBreaking (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
 		COMMENT Runs when the block is removed (by an entity or explosion).
 		ARG 1 world
@@ -411,17 +517,28 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 4 rand
 			COMMENT Random object
 	METHOD method_691 canBePlacedAdjacent (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;)Z
+		COMMENT Returns whether blocks can be placed adjacent to it.
+		COMMENT @return Whether blocks can be placed adjacent to it
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 direction
+			COMMENT The block's direction
 	METHOD method_692 blocksMovement (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)Z
 		ARG 1 view
 		ARG 2 pos
 	METHOD method_693 getStrongRedstonePower (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1383;)I
+		COMMENT Returns the block's strong redstone power.
+		COMMENT @return The Block's strong redstone power
 		ARG 1 view
+			COMMENT WorldView instance
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 facing
+			COMMENT The block's direction
 	METHOD method_695 isEqualTo (Lnet/minecraft/class_160;)Z
 		ARG 1 block
 	METHOD method_697 (Lnet/minecraft/class_649;)Z
@@ -471,7 +588,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_707 (Lnet/minecraft/class_649;)Z
 		ARG 1 vec
 	METHOD method_708 setTranslationKey (Ljava/lang/String;)Lnet/minecraft/class_160;
-		ARG 1 translation
+		COMMENT Sets the block's localization key. Used in registering blocks.
+		COMMENT @return The Current block
+		ARG 1 key
+			COMMENT The Translation key
 	METHOD method_709 renderAsNormalBlock ()Z
 		COMMENT Returns whether the block can be rendered as a normal block
 		COMMENT @return Whether the block can be rendered as a normal block
@@ -481,6 +601,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 0 id
 			COMMENT The BlockState's id
 	METHOD method_711 canBePlacedAtPos (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
+		COMMENT Returns whether the current block can be placed at a certain {@code BlockPos}
+		COMMENT @return Whether the current block can be placed at a BlockPos
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_712 onBreakByPlayer (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
@@ -498,12 +620,17 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 opacity
 			COMMENT The block's light opacity
 	METHOD method_716 getTranslatedName ()Ljava/lang/String;
+		COMMENT Translates and returns the translation key
+		COMMENT @return Translated name
 	METHOD method_717 getByBlockState (Lnet/minecraft/class_376;)I
 		COMMENT Returns a certain Block's id from a blockstate
 		COMMENT @return Block id
 		ARG 0 state
 			COMMENT The BlockState for which the id is returned
 	METHOD method_718 canMobSpawnInside ()Z
+		COMMENT Returns whether mobs can spawn inside the block.
+		COMMENT Used for Air.
+		COMMENT @return Whether mobs can spawn inside the block
 	METHOD method_719 getStrength (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
 		COMMENT Returns the current block's strength
 		COMMENT @return The block's strength
@@ -518,18 +645,30 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 state
 			COMMENT The Blockstate for which the material color is returned
 	METHOD method_721 getAmbientOcclusionLightLevel ()F
+		COMMENT Returns the block's ambient occlusion light level on the basis of whether it is a normal block.
+		COMMENT Only called on the client.
+		COMMENT @return The block's ambient occlusion light level
 	METHOD method_722 (Lnet/minecraft/class_376;)I
 		ARG 1 state
 	METHOD method_723 emitsRedstonePower ()Z
+		COMMENT Returns whether the current block emits a redstone signal.
+		COMMENT Used by comparators, Redstone Blocks, etc.
+		COMMENT @return Whether the current block emits a redstone signal
 	METHOD method_724 createStackFromBlock (Lnet/minecraft/class_376;)Lnet/minecraft/class_2056;
+		COMMENT Creates and returns and ItemStack from a block.
+		COMMENT @return An ItemStack instance containing the block
 		ARG 1 state
+			COMMENT The block's BlockState
 	METHOD method_725 setBlockItemBounds ()V
+		COMMENT Sets the bounds for the BlockItem
 	METHOD method_726 getMeta (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)I
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_727 setDefaultState (Lnet/minecraft/class_376;)V
 		ARG 1 state
 	METHOD method_728 getPistonInteractionType ()I
+		COMMENT Returns the block's piston interaction type, as provided by it's material.
+		COMMENT @return Current block's piston interaction type
 	METHOD method_729 rainTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)V
 		ARG 1 world
 		ARG 2 pos
@@ -537,6 +676,9 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_731 getRenderLayerType ()Lnet/minecraft/class_91;
+		COMMENT Returns the appropriate RenderLayer for a block.
+		COMMENT Only called on the client.
+		COMMENT @return The block's RenderLayer
 	METHOD method_732 isFullBlock ()Z
 		COMMENT Checks whether the current block is a full block
 		COMMENT @return fullBlock

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -1,20 +1,38 @@
 CLASS net/minecraft/class_160 net/minecraft/block/Block
 	COMMENT
 	FIELD field_576 blockEntity Z
+		COMMENT Specifies whether the current block has a block entity
 	FIELD field_577 boundingBoxMinX D
+		COMMENT Stores the Minimum value on the X axis for the voxel shape
 	FIELD field_578 boundingBoxMinY D
+		COMMENT Stores the Minimum value on the Y axis for the voxel shape
 	FIELD field_579 boundingBoxMinZ D
+		COMMENT Stores the Minimum value on the Z axis for the voxel shape
 	FIELD field_580 boundingBoxMaxX D
+		COMMENT Stores the Maximum value on the X axis for the voxel shape
 	FIELD field_581 boundingBoxMaxY D
+		COMMENT Stores the Maximum value on the Y axis for the voxel shape
 	FIELD field_582 boundingBoxMaxZ D
+		COMMENT Stores the Maximum value on the Z axis for the voxel shape
 	FIELD field_583 sound Lnet/minecraft/class_160$class_162;
+		COMMENT Stores the current block's sound type
 	FIELD field_584 particleGravity F
+		COMMENT Stores the current block's particles' gravity
 	FIELD field_585 material Lnet/minecraft/class_591;
+		COMMENT Stores the current block's material
+		COMMENT @see net.minecraft.block.Material
 	FIELD field_586 materialColor Lnet/minecraft/class_592;
+		COMMENT Stores the current block's material color
+		COMMENT @see net.minecraft.block.MaterialColor
 	FIELD field_587 slipperiness F
+		COMMENT Stores the current block's slipperiness
+		COMMENT Used By Ice and Packed Ice
 	FIELD field_588 stateManager Lnet/minecraft/class_378;
+		COMMENT Stores the block's state manager
 	FIELD field_589 blockState Lnet/minecraft/class_376;
+		COMMENT Stores the block's default state
 	FIELD field_590 translationKey Ljava/lang/String;
+		COMMENT Stores the block's translation key
 	FIELD field_591 AIR_ID Lnet/minecraft/class_1605;
 		COMMENT The Identifier for Air
 	FIELD field_592 itemGroup Lnet/minecraft/class_2029;
@@ -49,16 +67,22 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	FIELD field_607 SLIME Lnet/minecraft/class_160$class_162;
 		COMMENT Slime sound type
 	FIELD field_608 fullBlock Z
-		COMMENT Specifies whether the block is a full block
+		COMMENT Specifies whether the current block is a full block
 	FIELD field_609 opacity I
 		COMMENT Stores the light opacity of the block
 	FIELD field_610 transluscent Z
+		COMMENT Specifies whether the current block is transluscent
 	FIELD field_611 lightLevel I
+		COMMENT Stores the block's luminescence
 	FIELD field_612 useNeighbourLight Z
 	FIELD field_613 strength F
+		COMMENT Stores the current block's hardness
 	FIELD field_614 resistance F
+		COMMENT Stores the current block's resistance
 	FIELD field_615 stats Z
+		COMMENT Specifies whether the current block is tracked for stats
 	FIELD field_616 randomTicks Z
+		COMMENT Specifies whether the current block ticks randomly
 	METHOD <init> (Lnet/minecraft/class_591;)V
 		ARG 1 material
 	METHOD <init> (Lnet/minecraft/class_591;Lnet/minecraft/class_592;)V

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -94,6 +94,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 color
 			COMMENT The block's material color
 	METHOD method_615 hasCollision ()Z
+		COMMENT Returns whether a block has collision, i.e. stops entities
+		COMMENT @return Whether a block has collision
 	METHOD method_616 getMinX ()D
 	METHOD method_617 getMaxX ()D
 	METHOD method_618 getMinY ()D
@@ -116,12 +118,19 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 lightLevel
 			COMMENT The block's luminescence
 	METHOD method_636 setBoundingBox (FFFFFF)V
+		COMMENT Sets the block's bounding box. It accepts six parameters: The minimum and maximum for each of the three axes.
 		ARG 1 minX
+			COMMENT Minimum X value
 		ARG 2 minY
+			COMMENT Minimum Y value
 		ARG 3 minZ
+			COMMENT Minimum Z value
 		ARG 4 maxX
+			COMMENT Maximum X value
 		ARG 5 maxY
+			COMMENT Maximum Y value
 		ARG 6 maxZ
+			COMMENT Maximum Z value
 	METHOD method_637 stateFromData (I)Lnet/minecraft/class_376;
 		COMMENT Returns a blockstate of the current block from it's id
 		COMMENT @return The Default state
@@ -141,7 +150,11 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_641 shouldDropItemsOnExplosion (Lnet/minecraft/class_93;)Z
 		ARG 1 explosion
 	METHOD method_642 getTickRate (Lnet/minecraft/class_99;)I
+		COMMENT Returns the block's tick rate.
+		COMMENT Default is 10.
+		COMMENT @return Tick rate
 		ARG 1 world
+			COMMENT The world that the block is placed in
 	METHOD method_643 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
 		ARG 1 world
 		ARG 2 pos
@@ -150,15 +163,26 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 pos
 		ARG 3 explosion
 	METHOD method_645 getCollisionBox (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)Lnet/minecraft/class_646;
+		COMMENT Returns a box by adding the block's current location and the block's corresponding value in its Bounding Box
+		COMMENT @return The Collision box
 		ARG 1 world
+			COMMENT The world that the block has been placed
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 	METHOD method_646 randomDropAsItem (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;FI)V
+		COMMENT Called when the block must be dropped as an item by {@code dropAsItem}, but luck is taken into consideration here.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 chance
+			COMMENT The chance (luck factor)
 		ARG 5 id
+			COMMENT Id
 	METHOD method_647 onEvent (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;II)Z
 		ARG 1 world
 		ARG 2 pos
@@ -166,15 +190,26 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 4 id
 		ARG 5 meta
 	METHOD method_648 neighborUpdate (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_160;)V
+		COMMENT Runs when its adjacent blocks are updated.
+		COMMENT It will also run when the block is placed or removed as Air is being updated.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 block
+			COMMENT The adjacent Block that updated the current block
 	METHOD method_650 onUpdateTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Ljava/util/Random;)V
+		COMMENT Runs when the block is updated
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 rand
+			COMMENT Random object
 	METHOD method_651 onEntityCollision (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1745;)V
 		ARG 1 world
 		ARG 2 pos
@@ -252,9 +287,14 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 state
 		ARG 4 facing
 	METHOD method_668 isSideInvisible (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;)Z
+		COMMENT Returns whether the current block has connected sides, i.e its side faces are invisible when covered by other blocks. Used by glass to prevent the white dots from appearing everywhere through adjacent glass blocks.
+		COMMENT @return Whether the current block has connected sides
 		ARG 1 view
+			COMMENT WorldView instance
 		ARG 2 pos
+			COMMENT The current block's position
 		ARG 3 facing
+			COMMENT The direction the block is facing
 	METHOD method_669 setSound (Lnet/minecraft/class_160$class_162;)Lnet/minecraft/class_160;
 		COMMENT Sets the block's sound type. Used in registering blocks.
 		COMMENT @return The current block
@@ -280,22 +320,39 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 pos
 			COMMENT The block's position
 	METHOD method_674 getDropItem (Lnet/minecraft/class_376;Ljava/util/Random;I)Lnet/minecraft/class_2054;
+		COMMENT Returns the item that must be dropped when the block is broken
+		COMMENT @return The Item that drops after the block breaks
 		ARG 1 blockState
+			COMMENT The block's BlockState
 		ARG 2 random
+			COMMENT Random object
 		ARG 3 state
+			COMMENT State
 	METHOD method_675 canCollide (Lnet/minecraft/class_376;Z)Z
+		COMMENT Returns whether entities can collide with the block
+		COMMENT @return Whether the block has collision
 		ARG 1 state
+			COMMENT The block's BlockState
 		ARG 2 bl
 	METHOD method_676 (Lnet/minecraft/class_649;)Z
 		ARG 1 vec
 	METHOD method_677 getDropCount (Ljava/util/Random;)I
+		COMMENT Returns the amount of items the block should drop on breaking without bonus rolls.
+		COMMENT @return Amount of items to be dropped
 		ARG 1 rand
+			COMMENT Random object
 	METHOD method_678 getBlastResistance (Lnet/minecraft/class_1745;)F
 		ARG 1 entity
 	METHOD method_679 calcBlockBreakingData (Lnet/minecraft/class_1963;Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
+		COMMENT Calculates how fast or slow the block must be broken by a Player.
+		COMMENT  Status effects such as Haste and Mining fatigue are taken into consideration.
+		COMMENT @return Speed of breaking
 		ARG 1 player
+			COMMENT The player breaking the block
 		ARG 2 world
+			COMMENT The world that the block is placed in
 		ARG 3 pos
+			COMMENT The block's position
 	METHOD method_680 setItemGroup (Lnet/minecraft/class_2029;)Lnet/minecraft/class_160;
 		ARG 1 group
 	METHOD method_681 getBlockFromItem (Lnet/minecraft/class_2054;)Lnet/minecraft/class_160;
@@ -325,19 +382,34 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 pos
 		ARG 3 size
 	METHOD method_688 onBreaking (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
+		COMMENT Runs when the block is removed (by an entity or explosion).
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 	METHOD method_689 dropAsItem (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;I)V
+		COMMENT Runs when the block must be dropped as an item.
+		COMMENT Called when the block is broken or an enderman holding the block dies.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 id
+			COMMENT Id
 	METHOD method_690 scheduledTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Ljava/util/Random;)V
+		COMMENT Runs when the block is updated as per a schedule
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 rand
+			COMMENT Random object
 	METHOD method_691 canBePlacedAdjacent (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;)Z
 		ARG 1 world
 		ARG 2 pos
@@ -359,7 +431,6 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		COMMENT @return The block
 		ARG 0 id
 			COMMENT The block's name
-	METHOD method_699 getBoolean ()Z
 	METHOD method_700 setStrength (F)Lnet/minecraft/class_160;
 		COMMENT Sets the current block's strength. Used in registering blocks.
 		COMMENT @return The current block
@@ -374,14 +445,23 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_703 onCreation (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
+		COMMENT Runs when the block is placed (by a player or enderman).
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 	METHOD method_704 randomDisplayTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Ljava/util/Random;)V
+		COMMENT Runs every random display Tick. Useful for displaying particles around a block, like Redstone Ore.
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 		ARG 4 rand
+			COMMENT Random object
 	METHOD method_706 getData (Lnet/minecraft/class_376;)I
 		COMMENT Returns the data value for a blockstate
 		COMMENT Throws an {@code IllegalArmumentException} as this method does not work
@@ -404,9 +484,13 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_712 onBreakByPlayer (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
+		COMMENT Runs when the block is broken by the player
 		ARG 1 world
+			COMMENT The world that the block is placed in
 		ARG 2 pos
+			COMMENT The block's position
 		ARG 3 state
+			COMMENT The block's BlockState
 	METHOD method_714 appendProperties ()Lnet/minecraft/class_378;
 	METHOD method_715 setOpacity (I)Lnet/minecraft/class_160;
 		COMMENT Sets the block's light opacity. Used in registering blocks.

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -16,24 +16,42 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	FIELD field_589 blockState Lnet/minecraft/class_376;
 	FIELD field_590 translationKey Ljava/lang/String;
 	FIELD field_591 AIR_ID Lnet/minecraft/class_1605;
+		COMMENT The Identifier for Air
 	FIELD field_592 itemGroup Lnet/minecraft/class_2029;
 	FIELD field_593 REGISTRY Lnet/minecraft/class_1381;
+		COMMENT The Registry object to which all blocks get registered to
 	FIELD field_594 BLOCK_STATES Lnet/minecraft/class_1389;
+		COMMENT A List of all blockstates, used by Debug worlds
 	FIELD field_595 ORE Lnet/minecraft/class_160$class_162;
+		COMMENT Ore sound type
 	FIELD field_596 WOOD Lnet/minecraft/class_160$class_162;
+		COMMENT Wood sound type
 	FIELD field_597 GRAVEL Lnet/minecraft/class_160$class_162;
+		COMMENT Gravel sound type
 	FIELD field_598 GRASS Lnet/minecraft/class_160$class_162;
+		COMMENT Grass sound type
 	FIELD field_599 STONE Lnet/minecraft/class_160$class_162;
+		COMMENT Stone sound type
 	FIELD field_600 RAIL Lnet/minecraft/class_160$class_162;
+		COMMENT Rail sound type
 	FIELD field_601 GLASS Lnet/minecraft/class_160$class_162;
+		COMMENT Glass sound type
 	FIELD field_602 CLOTH Lnet/minecraft/class_160$class_162;
+		COMMENT Cloth sound type
 	FIELD field_603 SAND Lnet/minecraft/class_160$class_162;
+		COMMENT Sand sound type
 	FIELD field_604 SNOW Lnet/minecraft/class_160$class_162;
+		COMMENT Snow sound type
 	FIELD field_605 LADDER Lnet/minecraft/class_160$class_162;
+		COMMENT Ladder sound type
 	FIELD field_606 ANVIL Lnet/minecraft/class_160$class_162;
+		COMMENT Anvil sound type
 	FIELD field_607 SLIME Lnet/minecraft/class_160$class_162;
+		COMMENT Slime sound type
 	FIELD field_608 fullBlock Z
+		COMMENT Specifies whether the block is a full block
 	FIELD field_609 opacity I
+		COMMENT Stores the light opacity of the block
 	FIELD field_610 transluscent Z
 	FIELD field_611 lightLevel I
 	FIELD field_612 useNeighbourLight Z

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_160 net/minecraft/block/Block
-	COMMENT
+	COMMENT The Block class provides useful methods and fields for creation of Blocks.
+	COMMENT All blocks extend the Block class.
+	COMMENT The Block class also registers all the blocks.
 	FIELD field_576 blockEntity Z
 		COMMENT Specifies whether the current block has a block entity
 	FIELD field_577 boundingBoxMinX D
@@ -784,7 +786,9 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		FIELD field_618 XZ Lnet/minecraft/class_160$class_161;
 		FIELD field_619 XYZ Lnet/minecraft/class_160$class_161;
 	CLASS class_162 Sound
+		COMMENT
 		FIELD field_621 id Ljava/lang/String;
+			COMMENT
 		FIELD field_622 volume F
 		FIELD field_623 pitch F
 		METHOD <init> (Ljava/lang/String;FF)V

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_160 net/minecraft/block/Block
-	COMMENT Air, the filler block
+	COMMENT
+	FIELD field_576 blockEntity Z
 	FIELD field_577 boundingBoxMinX D
 	FIELD field_578 boundingBoxMinY D
 	FIELD field_579 boundingBoxMinZ D
@@ -7,8 +8,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	FIELD field_581 boundingBoxMaxY D
 	FIELD field_582 boundingBoxMaxZ D
 	FIELD field_583 sound Lnet/minecraft/class_160$class_162;
+	FIELD field_584 particleGravity F
 	FIELD field_585 material Lnet/minecraft/class_591;
 	FIELD field_586 materialColor Lnet/minecraft/class_592;
+	FIELD field_587 slipperiness F
 	FIELD field_588 stateManager Lnet/minecraft/class_378;
 	FIELD field_589 blockState Lnet/minecraft/class_376;
 	FIELD field_590 translationKey Ljava/lang/String;
@@ -29,18 +32,33 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	FIELD field_605 LADDER Lnet/minecraft/class_160$class_162;
 	FIELD field_606 ANVIL Lnet/minecraft/class_160$class_162;
 	FIELD field_607 SLIME Lnet/minecraft/class_160$class_162;
-	FIELD field_608 opaque Z
+	FIELD field_608 fullBlock Z
+	FIELD field_609 opacity I
+	FIELD field_610 transluscent Z
 	FIELD field_611 lightLevel I
+	FIELD field_612 useNeighbourLight Z
 	FIELD field_613 strength F
 	FIELD field_614 resistance F
-	FIELD field_616 tickRandomly Z
+	FIELD field_615 stats Z
+	FIELD field_616 randomTicks Z
 	METHOD <init> (Lnet/minecraft/class_591;)V
 		ARG 1 material
 	METHOD <init> (Lnet/minecraft/class_591;Lnet/minecraft/class_592;)V
 		ARG 1 material
 		ARG 2 color
+	METHOD method_615 hasCollision ()Z
+	METHOD method_616 getMinX ()D
+	METHOD method_617 getMaxX ()D
+	METHOD method_618 getMinY ()D
+	METHOD method_619 getMaxY ()D
+	METHOD method_620 getMinZ ()D
+	METHOD method_621 getMaxZ ()D
+	METHOD method_623 canSilkTouchHarvest ()Z
+	METHOD method_624 hasStats ()Z
+	METHOD method_625 disableStats ()Lnet/minecraft/class_160;
 	METHOD method_626 getItemGroup ()Lnet/minecraft/class_2029;
 	METHOD method_629 hasComparatorOutput ()Z
+	METHOD method_630 getStateManager ()Lnet/minecraft/class_378;
 	METHOD method_631 getDefaultState ()Lnet/minecraft/class_376;
 	METHOD method_632 getOffsetType ()Lnet/minecraft/class_160$class_161;
 	METHOD method_633 setup ()V
@@ -58,8 +76,15 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 data
 	METHOD method_638 register (ILjava/lang/String;Lnet/minecraft/class_160;)V
 		ARG 0 id
+		ARG 1 name
+		ARG 2 block
+	METHOD method_639 getBonusDrops (ILjava/util/Random;)I
+		ARG 1 id
+		ARG 2 rand
 	METHOD method_640 register (ILnet/minecraft/class_1605;Lnet/minecraft/class_160;)V
 		ARG 0 id
+		ARG 1 identifier
+		ARG 2 block
 	METHOD method_641 shouldDropItemsOnExplosion (Lnet/minecraft/class_93;)Z
 		ARG 1 explosion
 	METHOD method_642 getTickRate (Lnet/minecraft/class_99;)I
@@ -75,11 +100,28 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+	METHOD method_646 randomDropAsItem (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;FI)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 chance
+		ARG 5 id
+	METHOD method_647 onEvent (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;II)Z
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 id
+		ARG 5 meta
 	METHOD method_648 neighborUpdate (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_160;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
 		ARG 4 block
+	METHOD method_650 onUpdateTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Ljava/util/Random;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 rand
 	METHOD method_651 onEntityCollision (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1745;)V
 		ARG 1 world
 		ARG 2 pos
@@ -102,6 +144,22 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 state
 		ARG 4 rplayer
 		ARG 5 direction
+	METHOD method_655 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_649;Lnet/minecraft/class_649;)Lnet/minecraft/class_647;
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 vec1
+		ARG 4 vec2
+	METHOD method_656 getStateFromData (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;FFFILnet/minecraft/class_1752;)Lnet/minecraft/class_376;
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 dir
+		ARG 7 id
+		ARG 8 entity
+	METHOD method_657 canBeReplaced (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;Lnet/minecraft/class_2056;)Z
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 dir
+		ARG 4 stack
 	METHOD method_658 onSteppedOn (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1745;)V
 		ARG 1 world
 		ARG 2 pos
@@ -119,12 +177,22 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 item
+	METHOD method_663 setEntityVelocity (Lnet/minecraft/class_99;Lnet/minecraft/class_1745;)V
+		ARG 1 world
+		ARG 2 entity
+	METHOD method_664 harvest (Lnet/minecraft/class_99;Lnet/minecraft/class_1963;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_348;)V
+		ARG 1 world
+		ARG 2 player
+		ARG 3 pos
+		ARG 4 state
+		ARG 5 be
 	METHOD method_665 getOutlineShape (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)V
 		ARG 1 view
 		ARG 2 pos
 	METHOD method_666 getBlockColor (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;I)I
 		ARG 1 view
 		ARG 2 pos
+		ARG 3 id
 	METHOD method_667 getWeakRedstonePower (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1383;)I
 		ARG 1 view
 		ARG 2 pos
@@ -138,19 +206,34 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 sound
 	METHOD method_670 getIdByBlock (Lnet/minecraft/class_160;)I
 		ARG 0 block
+	METHOD method_671 areBlocksEqual (Lnet/minecraft/class_160;Lnet/minecraft/class_160;)Z
+		ARG 0 one
+		ARG 1 two
 	METHOD method_672 getMeta (Lnet/minecraft/class_376;)I
 		ARG 1 state
-	METHOD method_673 (Lnet/minecraft/class_376;Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)Lnet/minecraft/class_376;
+	METHOD method_673 getBlockState (Lnet/minecraft/class_376;Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)Lnet/minecraft/class_376;
 		ARG 1 state
+		ARG 2 view
 		ARG 3 pos
 	METHOD method_674 getDropItem (Lnet/minecraft/class_376;Ljava/util/Random;I)Lnet/minecraft/class_2054;
 		ARG 1 blockState
 		ARG 2 random
 		ARG 3 state
+	METHOD method_675 canCollide (Lnet/minecraft/class_376;Z)Z
+		ARG 1 state
+		ARG 2 bl
+	METHOD method_676 (Lnet/minecraft/class_649;)Z
+		ARG 1 vec
 	METHOD method_677 getDropCount (Ljava/util/Random;)I
 		ARG 1 rand
+	METHOD method_678 getBlastResistance (Lnet/minecraft/class_1745;)F
+		ARG 1 entity
 	METHOD method_679 calcBlockBreakingData (Lnet/minecraft/class_1963;Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
+		ARG 1 player
+		ARG 2 world
+		ARG 3 pos
 	METHOD method_680 setItemGroup (Lnet/minecraft/class_2029;)Lnet/minecraft/class_160;
+		ARG 1 group
 	METHOD method_681 getBlockFromItem (Lnet/minecraft/class_2054;)Lnet/minecraft/class_160;
 		ARG 0 item
 	METHOD method_682 appendStacks (Lnet/minecraft/class_2054;Lnet/minecraft/class_2029;Ljava/util/List;)V
@@ -159,6 +242,7 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 stacks
 	METHOD method_683 setTickRandomly (Z)Lnet/minecraft/class_160;
 		ARG 1 tickRandomly
+	METHOD method_684 getRenderType ()I
 	METHOD method_685 setResistance (F)Lnet/minecraft/class_160;
 		ARG 1 resistance
 	METHOD method_686 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Lnet/minecraft/class_646;
@@ -168,18 +252,39 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 size
+	METHOD method_688 onBreaking (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+	METHOD method_689 dropAsItem (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;I)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 id
 	METHOD method_690 scheduledTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Ljava/util/Random;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+		ARG 4 rand
+	METHOD method_691 canBePlacedAdjacent (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;)Z
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 direction
+	METHOD method_692 blocksMovement (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)Z
+		ARG 1 view
+		ARG 2 pos
 	METHOD method_693 getStrongRedstonePower (Lnet/minecraft/class_104;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Lnet/minecraft/class_1383;)I
 		ARG 1 view
 		ARG 2 pos
 		ARG 3 state
 		ARG 4 facing
+	METHOD method_695 isEqualTo (Lnet/minecraft/class_160;)Z
+		ARG 1 block
+	METHOD method_697 (Lnet/minecraft/class_649;)Z
+		ARG 1 vec
 	METHOD method_698 get (Ljava/lang/String;)Lnet/minecraft/class_160;
 		ARG 0 id
-	METHOD method_699 isOpaque ()Z
+	METHOD method_699 getBoolean ()Z
 	METHOD method_700 setStrength (F)Lnet/minecraft/class_160;
 		ARG 1 strength
 	METHOD method_701 byId (I)Lnet/minecraft/class_160;
@@ -187,45 +292,75 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_702 getPickItem (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Lnet/minecraft/class_2054;
 		ARG 1 world
 		ARG 2 pos
+	METHOD method_703 onCreation (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
 	METHOD method_704 randomDisplayTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Ljava/util/Random;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+		ARG 4 rand
 	METHOD method_706 getData (Lnet/minecraft/class_376;)I
 		ARG 1 state
+	METHOD method_707 (Lnet/minecraft/class_649;)Z
+		ARG 1 vec
 	METHOD method_708 setTranslationKey (Ljava/lang/String;)Lnet/minecraft/class_160;
 		ARG 1 translation
+	METHOD method_709 renderAsNormalBlock ()Z
 	METHOD method_710 getStateFromRawId (I)Lnet/minecraft/class_376;
 		ARG 0 stateId
+	METHOD method_711 canBePlacedAtPos (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
+		ARG 1 world
+		ARG 2 pos
+	METHOD method_712 onBreakByPlayer (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
 	METHOD method_714 appendProperties ()Lnet/minecraft/class_378;
+	METHOD method_715 setOpacity (I)Lnet/minecraft/class_160;
+		ARG 1 opacity
 	METHOD method_716 getTranslatedName ()Ljava/lang/String;
 	METHOD method_717 getByBlockState (Lnet/minecraft/class_376;)I
 		ARG 0 state
 	METHOD method_718 canMobSpawnInside ()Z
-	METHOD method_719 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
+	METHOD method_719 getStrength (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_720 getMaterialColor (Lnet/minecraft/class_376;)Lnet/minecraft/class_592;
 		ARG 1 state
 	METHOD method_721 getAmbientOcclusionLightLevel ()F
+	METHOD method_722 (Lnet/minecraft/class_376;)I
+		ARG 1 state
 	METHOD method_723 emitsRedstonePower ()Z
+	METHOD method_724 createStackFromBlock (Lnet/minecraft/class_376;)Lnet/minecraft/class_2056;
+		ARG 1 state
+	METHOD method_725 setBlockItemBounds ()V
 	METHOD method_726 getMeta (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)I
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_727 setDefaultState (Lnet/minecraft/class_376;)V
 		ARG 1 state
+	METHOD method_728 getPistonInteractionType ()I
 	METHOD method_729 rainTick (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)V
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_730 getComparatorOutput (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)I
 		ARG 1 world
 		ARG 2 pos
-	METHOD method_731 getRenderLayer ()Lnet/minecraft/class_91;
+	METHOD method_731 getRenderLayerType ()Lnet/minecraft/class_91;
+	METHOD method_732 isFullBlock ()Z
+	METHOD method_733 getOpacity ()I
+	METHOD method_734 isTransluscent ()Z
 	METHOD method_735 getLightLevel ()I
+	METHOD method_736 usesNeighbourLight ()Z
 	METHOD method_737 getMaterial ()Lnet/minecraft/class_591;
-	METHOD method_738 isFullCube ()Z
+	METHOD method_738 isNormalBlock ()Z
+	METHOD method_739 isFullCube ()Z
+	METHOD method_740 isLeafBlock ()Z
 	METHOD method_741 setUnbreakable ()Lnet/minecraft/class_160;
 	METHOD method_742 ticksRandomly ()Z
+	METHOD method_743 hasBlockEntity ()Z
 	CLASS class_161 OffsetType
 		FIELD field_617 NONE Lnet/minecraft/class_160$class_161;
 		FIELD field_618 XZ Lnet/minecraft/class_160$class_161;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -84,10 +84,15 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	FIELD field_616 randomTicks Z
 		COMMENT Specifies whether the current block ticks randomly
 	METHOD <init> (Lnet/minecraft/class_591;)V
+		COMMENT Overloaded Block constructor that calls the other with the default material color
 		ARG 1 material
+			COMMENT The block's material
 	METHOD <init> (Lnet/minecraft/class_591;Lnet/minecraft/class_592;)V
+		COMMENT Block constructor which initializes all fields to their default values and assigns the material and material color to the specified parameters
 		ARG 1 material
+			COMMENT The block's material
 		ARG 2 color
+			COMMENT The block's material color
 	METHOD method_615 hasCollision ()Z
 	METHOD method_616 getMinX ()D
 	METHOD method_617 getMaxX ()D
@@ -106,7 +111,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_633 setup ()V
 	METHOD method_634 getTranslationKey ()Ljava/lang/String;
 	METHOD method_635 setLightLevel (F)Lnet/minecraft/class_160;
+		COMMENT Sets the block's luminescence. Used in registering blocks.
+		COMMENT @return The current block
 		ARG 1 lightLevel
+			COMMENT The block's luminescence
 	METHOD method_636 setBoundingBox (FFFFFF)V
 		ARG 1 minX
 		ARG 2 minY
@@ -115,7 +123,10 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 5 maxY
 		ARG 6 maxZ
 	METHOD method_637 stateFromData (I)Lnet/minecraft/class_376;
+		COMMENT Returns a blockstate of the current block from it's id
+		COMMENT @return The Default state
 		ARG 1 data
+			COMMENT The Blockstate's associated data value
 	METHOD method_638 register (ILjava/lang/String;Lnet/minecraft/class_160;)V
 		ARG 0 id
 		ARG 1 name
@@ -245,18 +256,29 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 pos
 		ARG 3 facing
 	METHOD method_669 setSound (Lnet/minecraft/class_160$class_162;)Lnet/minecraft/class_160;
+		COMMENT Sets the block's sound type. Used in registering blocks.
+		COMMENT @return The current block
 		ARG 1 sound
+			COMMENT The block's sound type
 	METHOD method_670 getIdByBlock (Lnet/minecraft/class_160;)I
+		COMMENT Returns a certain block's id
+		COMMENT @return Block id
 		ARG 0 block
+			COMMENT The block for which the id is returned
 	METHOD method_671 areBlocksEqual (Lnet/minecraft/class_160;Lnet/minecraft/class_160;)Z
 		ARG 0 one
 		ARG 1 two
 	METHOD method_672 getMeta (Lnet/minecraft/class_376;)I
 		ARG 1 state
 	METHOD method_673 getBlockState (Lnet/minecraft/class_376;Lnet/minecraft/class_104;Lnet/minecraft/class_1372;)Lnet/minecraft/class_376;
+		COMMENT Returns the current block's blockstate at a certain position
+		COMMENT @return state
 		ARG 1 state
+			COMMENT The original blockstate
 		ARG 2 view
+			COMMENT WorldView instance
 		ARG 3 pos
+			COMMENT The block's position
 	METHOD method_674 getDropItem (Lnet/minecraft/class_376;Ljava/util/Random;I)Lnet/minecraft/class_2054;
 		ARG 1 blockState
 		ARG 2 random
@@ -277,16 +299,24 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_680 setItemGroup (Lnet/minecraft/class_2029;)Lnet/minecraft/class_160;
 		ARG 1 group
 	METHOD method_681 getBlockFromItem (Lnet/minecraft/class_2054;)Lnet/minecraft/class_160;
+		COMMENT Returns a block by converting a blockitem to a block
+		COMMENT @return The block
 		ARG 0 item
+			COMMENT The item that must be converted to a block
 	METHOD method_682 appendStacks (Lnet/minecraft/class_2054;Lnet/minecraft/class_2029;Ljava/util/List;)V
 		ARG 1 item
 		ARG 2 group
 		ARG 3 stacks
 	METHOD method_683 setTickRandomly (Z)Lnet/minecraft/class_160;
+		COMMENT Sets whether the current block has random ticks. Used in registering blocks.
+		COMMENT @return The current block
 		ARG 1 tickRandomly
-	METHOD method_684 getRenderType ()I
+			COMMENT Whether the current block should have random ticks
 	METHOD method_685 setResistance (F)Lnet/minecraft/class_160;
+		COMMENT Sets the block's resistance. Used in registering blocks.
+		COMMENT @return The current block
 		ARG 1 resistance
+			COMMENT The block's resistance
 	METHOD method_686 (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Lnet/minecraft/class_646;
 		ARG 1 world
 		ARG 2 pos
@@ -325,12 +355,21 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_697 (Lnet/minecraft/class_649;)Z
 		ARG 1 vec
 	METHOD method_698 get (Ljava/lang/String;)Lnet/minecraft/class_160;
+		COMMENT Returns a block from it's name
+		COMMENT @return The block
 		ARG 0 id
+			COMMENT The block's name
 	METHOD method_699 getBoolean ()Z
 	METHOD method_700 setStrength (F)Lnet/minecraft/class_160;
+		COMMENT Sets the current block's strength. Used in registering blocks.
+		COMMENT @return The current block
 		ARG 1 strength
-	METHOD method_701 byId (I)Lnet/minecraft/class_160;
+			COMMENT The block's strength
+	METHOD method_701 getById (I)Lnet/minecraft/class_160;
+		COMMENT Returns a certain block from its id
+		COMMENT @return The Block
 		ARG 0 id
+			COMMENT The id for which the Block is returned
 	METHOD method_702 getPickItem (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Lnet/minecraft/class_2054;
 		ARG 1 world
 		ARG 2 pos
@@ -344,14 +383,23 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 state
 		ARG 4 rand
 	METHOD method_706 getData (Lnet/minecraft/class_376;)I
+		COMMENT Returns the data value for a blockstate
+		COMMENT Throws an {@code IllegalArmumentException} as this method does not work
+		COMMENT @return Zero
 		ARG 1 state
+			COMMENT The Blockstate
 	METHOD method_707 (Lnet/minecraft/class_649;)Z
 		ARG 1 vec
 	METHOD method_708 setTranslationKey (Ljava/lang/String;)Lnet/minecraft/class_160;
 		ARG 1 translation
 	METHOD method_709 renderAsNormalBlock ()Z
+		COMMENT Returns whether the block can be rendered as a normal block
+		COMMENT @return Whether the block can be rendered as a normal block
 	METHOD method_710 getStateFromRawId (I)Lnet/minecraft/class_376;
-		ARG 0 stateId
+		COMMENT Returns a BlockState from it's id
+		COMMENT @return The Blockstate
+		ARG 0 id
+			COMMENT The BlockState's id
 	METHOD method_711 canBePlacedAtPos (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
 		ARG 1 world
 		ARG 2 pos
@@ -361,16 +409,30 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 state
 	METHOD method_714 appendProperties ()Lnet/minecraft/class_378;
 	METHOD method_715 setOpacity (I)Lnet/minecraft/class_160;
+		COMMENT Sets the block's light opacity. Used in registering blocks.
+		COMMENT @return The current block
 		ARG 1 opacity
+			COMMENT The block's light opacity
 	METHOD method_716 getTranslatedName ()Ljava/lang/String;
 	METHOD method_717 getByBlockState (Lnet/minecraft/class_376;)I
+		COMMENT Returns a certain Block's id from a blockstate
+		COMMENT @return Block id
 		ARG 0 state
+			COMMENT The BlockState for which the id is returned
 	METHOD method_718 canMobSpawnInside ()Z
 	METHOD method_719 getStrength (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)F
+		COMMENT Returns the current block's strength
+		COMMENT @return The block's strength
 		ARG 1 world
+			COMMENT The world where the block is placed
 		ARG 2 pos
+			COMMENT The block's position
 	METHOD method_720 getMaterialColor (Lnet/minecraft/class_376;)Lnet/minecraft/class_592;
+		COMMENT Returns the block's material color from it's state
+		COMMENT Blockstates can have different material colors
+		COMMENT @return materialColor
 		ARG 1 state
+			COMMENT The Blockstate for which the material color is returned
 	METHOD method_721 getAmbientOcclusionLightLevel ()F
 	METHOD method_722 (Lnet/minecraft/class_376;)I
 		ARG 1 state
@@ -392,17 +454,44 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 pos
 	METHOD method_731 getRenderLayerType ()Lnet/minecraft/class_91;
 	METHOD method_732 isFullBlock ()Z
+		COMMENT Checks whether the current block is a full block
+		COMMENT @return fullBlock
 	METHOD method_733 getOpacity ()I
+		COMMENT Returns the current block's opacity
+		COMMENT @return opacity
 	METHOD method_734 isTransluscent ()Z
+		COMMENT Checks whether the current block is transluscent
+		COMMENT @return transluscent
 	METHOD method_735 getLightLevel ()I
+		COMMENT Returns the block's luminescence
+		COMMENT @return lightLevel
 	METHOD method_736 usesNeighbourLight ()Z
+		COMMENT Checks whether the current block uses light from the adjacent block
+		COMMENT @return useNeighbourLight
 	METHOD method_737 getMaterial ()Lnet/minecraft/class_591;
+		COMMENT Returns the block's material
+		COMMENT @return material
 	METHOD method_738 isNormalBlock ()Z
+		COMMENT Checks whether the block is a normal block.
+		COMMENT A normal block is one that blocks movement and can be rendered as a normal block.
+		COMMENT @return Whether the block is a normal block
 	METHOD method_739 isFullCube ()Z
+		COMMENT Checks whether the current block is a full cube.
+		COMMENT A block is a full cube when it can be rendered as a normal block, does not emit redstone power and is opaque.
+		COMMENT @return Whether the current block is a full cube
 	METHOD method_740 isLeafBlock ()Z
+		COMMENT Checks whether the current block is a normal block (used only by {@code LeavesBlock})
+		COMMENT @return Whether the current block is a normal block
 	METHOD method_741 setUnbreakable ()Lnet/minecraft/class_160;
+		COMMENT Sets the current block as unbreakable. Used in registering blocks.
+		COMMENT Setting the strength as -1 makes the block unbreakable. Used by barriers and command blocks.
+		COMMENT @return The current block
 	METHOD method_742 ticksRandomly ()Z
+		COMMENT Returns whether the current block has random ticks
+		COMMENT @return Whether the current block has random ticks
 	METHOD method_743 hasBlockEntity ()Z
+		COMMENT Returns whether the current block has a block entity
+		COMMENT @return Whether the current block has a block entity
 	CLASS class_161 OffsetType
 		FIELD field_617 NONE Lnet/minecraft/class_160$class_161;
 		FIELD field_618 XZ Lnet/minecraft/class_160$class_161;

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_376 net/minecraft/block/BlockState
+	COMMENT
 	METHOD method_1222 getProperties ()Ljava/util/Collection;
 	METHOD method_1224 with (Lnet/minecraft/class_392;Ljava/lang/Comparable;)Lnet/minecraft/class_376;
 	METHOD method_1226 get (Lnet/minecraft/class_392;)Ljava/lang/Comparable;

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_376 net/minecraft/block/BlockState
+	METHOD method_1222 getProperties ()Ljava/util/Collection;
 	METHOD method_1224 with (Lnet/minecraft/class_392;Ljava/lang/Comparable;)Lnet/minecraft/class_376;
 	METHOD method_1226 get (Lnet/minecraft/class_392;)Ljava/lang/Comparable;
+		ARG 1 property
 	METHOD method_1227 getBlock ()Lnet/minecraft/class_160;

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -9,8 +9,12 @@ CLASS net/minecraft/class_591 net/minecraft/block/Material
 	FIELD field_2182 PISTON Lnet/minecraft/class_591;
 	FIELD field_2183 BARRIER Lnet/minecraft/class_591;
 	FIELD field_2184 burnable Z
+	FIELD field_2185 replaceable Z
+	FIELD field_2186 requiresSilkTouch Z
 	FIELD field_2187 color Lnet/minecraft/class_592;
 	FIELD field_2188 blocksMovement Z
+	FIELD field_2189 pistonInteractionType I
+	FIELD field_2190 canBeBrokenInAdventureMode Z
 	FIELD field_2191 AIR Lnet/minecraft/class_591;
 	FIELD field_2192 GRASS Lnet/minecraft/class_591;
 	FIELD field_2193 DIRT Lnet/minecraft/class_591;
@@ -39,11 +43,17 @@ CLASS net/minecraft/class_591 net/minecraft/block/Material
 	FIELD field_2216 SNOW Lnet/minecraft/class_591;
 	METHOD <init> (Lnet/minecraft/class_592;)V
 		ARG 1 color
+	METHOD method_1802 blocksMovement ()Z
 	METHOD method_1804 requiresTool ()Lnet/minecraft/class_591;
 	METHOD method_1805 setFlammable ()Lnet/minecraft/class_591;
 	METHOD method_1806 isBurnable ()Z
-	METHOD method_1810 blocksMovement ()Z
-	METHOD method_1812 setTranslucent ()Lnet/minecraft/class_591;
-	METHOD method_1814 setAsGlassLike ()Lnet/minecraft/class_591;
+	METHOD method_1807 setReplaceable ()Lnet/minecraft/class_591;
+	METHOD method_1808 isReplaceable ()Z
+	METHOD method_1809 isOpaque ()Z
+	METHOD method_1810 doesBlockMovement ()Z
+	METHOD method_1811 getPistonInteractionType ()I
+	METHOD method_1812 setNoPushing ()Lnet/minecraft/class_591;
+	METHOD method_1813 setImmovable ()Lnet/minecraft/class_591;
+	METHOD method_1814 setCanBeBrokenInAdventureMode ()Lnet/minecraft/class_591;
 	METHOD method_1815 getColor ()Lnet/minecraft/class_592;
 	METHOD method_1816 requiresSilkTouch ()Lnet/minecraft/class_591;

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -43,6 +43,7 @@ CLASS net/minecraft/class_591 net/minecraft/block/Material
 	FIELD field_2216 SNOW Lnet/minecraft/class_591;
 	METHOD <init> (Lnet/minecraft/class_592;)V
 		ARG 1 color
+	METHOD method_1801 isTransluscent ()Z
 	METHOD method_1802 blocksMovement ()Z
 	METHOD method_1804 requiresTool ()Lnet/minecraft/class_591;
 	METHOD method_1805 setFlammable ()Lnet/minecraft/class_591;

--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_91 net/minecraft/client/render/RenderLayer
+	COMMENT
 	FIELD field_218 SOLID Lnet/minecraft/class_91;
 	FIELD field_219 CUTOUT_MIPPED Lnet/minecraft/class_91;
 	FIELD field_220 CUTOUT Lnet/minecraft/class_91;

--- a/mappings/net/minecraft/stat/Stats.mapping
+++ b/mappings/net/minecraft/stat/Stats.mapping
@@ -27,6 +27,7 @@ CLASS net/minecraft/class_1687 net/minecraft/stat/Stats
 	FIELD field_6993 INTERACT_WITH_CRAFTING_TABLE Lnet/minecraft/class_1681;
 	FIELD field_6994 ID_TO_STAT Ljava/util/Map;
 	FIELD field_6995 CHEST_OPENED Lnet/minecraft/class_1681;
+	FIELD field_6996 BLOCK_STATS [Lnet/minecraft/class_1681;
 	FIELD field_7004 GAMES_LEFT Lnet/minecraft/class_1681;
 	FIELD field_7005 MINUTES_PLAYED Lnet/minecraft/class_1681;
 	FIELD field_7006 TIME_SINCE_DEATH Lnet/minecraft/class_1681;

--- a/mappings/net/minecraft/util/registry/DefaultedRegistry.mapping
+++ b/mappings/net/minecraft/util/registry/DefaultedRegistry.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1381 net/minecraft/util/registry/DefaultedRegistry
+	COMMENT
 	FIELD field_5795 objectType Ljava/lang/Object;
 	FIELD field_5796 defaultValue Ljava/lang/Object;
 	METHOD <init> (Ljava/lang/Object;)V


### PR DESCRIPTION
Every first mod starts with a block. Well, that's true for me. Blocks are a simple and easy component to implement into the game, so they should be given high priority and be well documented. This was probably the craziest and hardest Javadoc I had to write so I hope it's worth it.

*Again, please don't squash merge*

Changelog:-
```scala
 Changes to be committed:
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/block/BlockState.mapping
	modified:   mappings/net/minecraft/block/Material.mapping
	modified:   mappings/net/minecraft/stat/Stats.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/util/registry/DefaultedRegistry.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/block/BlockState.mapping
	modified:   mappings/net/minecraft/block/Material.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
```