### PR TITLE
Enchantments and Blockstate properties

### DIFF
--- a/mappings/net/minecraft/block/AbstractButtonBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractButtonBlock.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_168 net/minecraft/block/AbstractButtonBlock
 	FIELD field_823 wooden Z
+	FIELD field_824 FACING Lnet/minecraft/class_389;
+	FIELD field_825 POWERED Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/AbstractFluidBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractFluidBlock.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_243 net/minecraft/block/AbstractFluidBlock
+	FIELD field_1031 LEVEL Lnet/minecraft/class_391;
+	METHOD method_905 getFluidByMaterial (Lnet/minecraft/class_591;)Lnet/minecraft/class_313;
+		ARG 0 material

--- a/mappings/net/minecraft/block/AbstractRailBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractRailBlock.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_154 net/minecraft/block/AbstractRailBlock
 	FIELD field_543 allowCurves Z
+	METHOD <init> (Z)V
+		ARG 1 allowCurves
 	METHOD method_590 updateBlockState (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;Z)Lnet/minecraft/class_376;
 		ARG 1 world
 		ARG 2 pos
@@ -11,6 +13,7 @@ CLASS net/minecraft/class_154 net/minecraft/block/AbstractRailBlock
 		ARG 3 state
 		ARG 4 block
 	METHOD method_592 isRail (Lnet/minecraft/class_376;)Z
+		ARG 0 state
 	METHOD method_593 isRail (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
 		ARG 0 world
 		ARG 1 pos
@@ -57,4 +60,3 @@ CLASS net/minecraft/class_154 net/minecraft/block/AbstractRailBlock
 		METHOD method_608 getById (I)Lnet/minecraft/class_154$class_156;
 			ARG 0 id
 		METHOD method_609 isAscending ()Z
-		METHOD values ()[Lnet/minecraft/class_154$class_156;

--- a/mappings/net/minecraft/block/AnvilBlock.mapping
+++ b/mappings/net/minecraft/block/AnvilBlock.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_145 net/minecraft/block/AnvilBlock
+	FIELD field_536 FACING Lnet/minecraft/class_389;
+	FIELD field_537 DAMAGE Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/AttachedStemBlock.mapping
+++ b/mappings/net/minecraft/block/AttachedStemBlock.mapping
@@ -1,2 +1,10 @@
 CLASS net/minecraft/class_314 net/minecraft/block/AttachedStemBlock
+	FIELD field_1215 mainBlock Lnet/minecraft/class_160;
+	FIELD field_1216 AGE Lnet/minecraft/class_391;
+	FIELD field_1217 FACING Lnet/minecraft/class_389;
+	METHOD <init> (Lnet/minecraft/class_160;)V
+		ARG 1 mainBlock
 	METHOD method_1016 getSeeds ()Lnet/minecraft/class_2054;
+	CLASS 1
+		METHOD apply (Ljava/lang/Object;)Z
+			ARG 1 direction

--- a/mappings/net/minecraft/block/BaseLeavesBlock.mapping
+++ b/mappings/net/minecraft/block/BaseLeavesBlock.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_328 net/minecraft/block/BaseLeavesBlock
+	FIELD field_1278 fancyGraphics Z
+	METHOD <init> (Lnet/minecraft/class_591;Z)V
+		ARG 1 material
+		ARG 2 fancy

--- a/mappings/net/minecraft/block/BigMushroomBlock.mapping
+++ b/mappings/net/minecraft/block/BigMushroomBlock.mapping
@@ -23,3 +23,4 @@ CLASS net/minecraft/class_234 net/minecraft/block/BigMushroomBlock
 		METHOD method_883 getId ()I
 		METHOD method_884 getById (I)Lnet/minecraft/class_234$class_235;
 			ARG 0 id
+		METHOD values ()[Lnet/minecraft/class_234$class_235;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -116,9 +116,7 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 	METHOD method_621 getMaxZ ()D
 		COMMENT Returns the block's bounding box' maximum Z value
 		COMMENT @return Maximum Z value
-	METHOD method_623 canSilkTouchHarvest ()Z
-		COMMENT Returns whether the block can be harvested using Silk Touch.
-		COMMENT @return Whether the block can be harvested using Silk Touch
+	METHOD method_623 requiresSilkTouch ()Z
 	METHOD method_624 hasStats ()Z
 		COMMENT Returns whether the current block should be tracked for stats
 		COMMENT @return Whether the current block should be tracked for stats
@@ -512,6 +510,7 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		COMMENT @return The current block
 		ARG 1 tickRandomly
 			COMMENT Whether the current block should have random ticks
+	METHOD method_684 getBlockType ()I
 	METHOD method_685 setResistance (F)Lnet/minecraft/class_160;
 		COMMENT Sets the block's resistance. Used in registering blocks.
 		COMMENT @return The current block

--- a/mappings/net/minecraft/block/BlockEntityProvider.mapping
+++ b/mappings/net/minecraft/block/BlockEntityProvider.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_205 net/minecraft/block/BlockEntityProvider
 	METHOD method_841 createBlockEntity (Lnet/minecraft/class_99;I)Lnet/minecraft/class_348;
 		ARG 1 world
+		ARG 2 id

--- a/mappings/net/minecraft/block/BrewingStandBlock.mapping
+++ b/mappings/net/minecraft/block/BrewingStandBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_166 net/minecraft/block/BrewingStandBlock
+	FIELD field_822 HAS_BOTTLES [Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/CactusBlock.mapping
+++ b/mappings/net/minecraft/block/CactusBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_169 net/minecraft/block/CactusBlock
+	FIELD field_827 AGE Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/CarpetBlock.mapping
+++ b/mappings/net/minecraft/block/CarpetBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_342 net/minecraft/block/CarpetBlock
+	FIELD field_1325 COLOR Lnet/minecraft/class_390;

--- a/mappings/net/minecraft/block/CauldronBlock.mapping
+++ b/mappings/net/minecraft/block/CauldronBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_172 net/minecraft/block/CauldronBlock
+	FIELD field_829 LEVEL Lnet/minecraft/class_391;
 	METHOD method_764 setLevel (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;I)V
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/ChestBlock.mapping
+++ b/mappings/net/minecraft/block/ChestBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_173 net/minecraft/block/ChestBlock
+	FIELD field_830 FACING Lnet/minecraft/class_389;

--- a/mappings/net/minecraft/block/ComparatorBlock.mapping
+++ b/mappings/net/minecraft/block/ComparatorBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_178 net/minecraft/block/ComparatorBlock
+	FIELD field_836 POWERED Lnet/minecraft/class_388;
+	FIELD field_837 MODE Lnet/minecraft/class_390;
 	METHOD method_775 calculateOutputSignal (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)I
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/ConcretePowderBlock.mapping
+++ b/mappings/net/minecraft/block/ConcretePowderBlock.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_818 net/minecraft/block/ConcretePowderBlock

--- a/mappings/net/minecraft/block/DispenserBlock.mapping
+++ b/mappings/net/minecraft/block/DispenserBlock.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/class_191 net/minecraft/block/DispenserBlock
 	FIELD field_864 SPECIAL_ITEMS Lnet/minecraft/class_1382;
 	FIELD field_865 random Ljava/util/Random;
+	FIELD field_866 FACING Lnet/minecraft/class_389;
+	FIELD field_867 TRIGGERED Lnet/minecraft/class_388;
 	METHOD method_811 getBehaviorForItem (Lnet/minecraft/class_2056;)Lnet/minecraft/class_1387;
 		ARG 1 stack
 	METHOD method_814 dispense (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)V

--- a/mappings/net/minecraft/block/DoorBlock.mapping
+++ b/mappings/net/minecraft/block/DoorBlock.mapping
@@ -1,4 +1,9 @@
 CLASS net/minecraft/class_192 net/minecraft/block/DoorBlock
+	FIELD field_868 HINGE Lnet/minecraft/class_390;
+	FIELD field_869 POWERED Lnet/minecraft/class_388;
+	FIELD field_870 HALF Lnet/minecraft/class_390;
+	FIELD field_871 FACING Lnet/minecraft/class_389;
+	FIELD field_872 OPEN Lnet/minecraft/class_388;
 	CLASS class_193 HalfType
 		FIELD field_873 UPPER Lnet/minecraft/class_192$class_193;
 		FIELD field_874 LOWER Lnet/minecraft/class_192$class_193;

--- a/mappings/net/minecraft/block/EndPortalFrameBlock.mapping
+++ b/mappings/net/minecraft/block/EndPortalFrameBlock.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_203 net/minecraft/block/EndPortalFrameBlock
+	FIELD field_898 FACING Lnet/minecraft/class_389;
+	FIELD field_899 EYE Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/EnderChestBlock.mapping
+++ b/mappings/net/minecraft/block/EnderChestBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_204 net/minecraft/block/EnderChestBlock
+	FIELD field_900 FACING Lnet/minecraft/class_389;

--- a/mappings/net/minecraft/block/FacingBlock.mapping
+++ b/mappings/net/minecraft/block/FacingBlock.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_188 net/minecraft/block/FacingBlock
-	FIELD field_852 FACING Lnet/minecraft/class_389;

--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_208 net/minecraft/block/FenceBlock
+	FIELD field_904 SOUTH Lnet/minecraft/class_388;
+	FIELD field_905 WEST Lnet/minecraft/class_388;
+	FIELD field_906 NORTH Lnet/minecraft/class_388;
+	FIELD field_907 EAST Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/FenceGateBlock.mapping
+++ b/mappings/net/minecraft/block/FenceGateBlock.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_209 net/minecraft/block/FenceGateBlock
+	FIELD field_908 IN_WALL Lnet/minecraft/class_388;
+	FIELD field_909 OPEN Lnet/minecraft/class_388;
+	FIELD field_910 POWERED Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/FireBlock.mapping
+++ b/mappings/net/minecraft/block/FireBlock.mapping
@@ -1,10 +1,24 @@
 CLASS net/minecraft/class_210 net/minecraft/block/FireBlock
+	FIELD field_911 ALT Lnet/minecraft/class_388;
+	FIELD field_912 NORTH Lnet/minecraft/class_388;
+	FIELD field_913 EAST Lnet/minecraft/class_388;
+	FIELD field_914 SOUTH Lnet/minecraft/class_388;
+	FIELD field_915 WEST Lnet/minecraft/class_388;
+	FIELD field_916 UPPER Lnet/minecraft/class_391;
+	FIELD field_917 BLOCKS_BY_FLAMMABILITY Ljava/util/Map;
+	FIELD field_918 BLOCKS_BY_MODIFIER Ljava/util/Map;
+	FIELD field_919 AGE Lnet/minecraft/class_391;
+	FIELD field_920 FLIP Lnet/minecraft/class_388;
 	METHOD method_849 trySpreadingFire (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;ILjava/util/Random;I)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 spreadFactor
 		ARG 4 rand
 		ARG 5 currentAge
+	METHOD method_850 registerFlammableBlock (Lnet/minecraft/class_160;II)V
+		ARG 1 block
+		ARG 2 flamability
+		ARG 3 disappearPercentage
 	METHOD method_853 isRainingAround (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/FlowerPotBlock.mapping
+++ b/mappings/net/minecraft/block/FlowerPotBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_214 net/minecraft/block/FlowerPotBlock
+	FIELD field_943 LEGACY_DATA Lnet/minecraft/class_391;
+	FIELD field_944 CONTENTS Lnet/minecraft/class_390;
 	CLASS class_215 PottablePlantType
 		FIELD field_947 EMPTY Lnet/minecraft/class_214$class_215;
 		FIELD field_948 POPPY Lnet/minecraft/class_214$class_215;

--- a/mappings/net/minecraft/block/FurnaceBlock.mapping
+++ b/mappings/net/minecraft/block/FurnaceBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_220 net/minecraft/block/FurnaceBlock
+	FIELD field_972 FACING Lnet/minecraft/class_389;

--- a/mappings/net/minecraft/block/GrassBlock.mapping
+++ b/mappings/net/minecraft/block/GrassBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_223 net/minecraft/block/GrassBlock
+	FIELD field_975 SNOWY Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/HopperBlock.mapping
+++ b/mappings/net/minecraft/block/HopperBlock.mapping
@@ -1,5 +1,10 @@
 CLASS net/minecraft/class_233 net/minecraft/block/HopperBlock
+	FIELD field_982 FACING Lnet/minecraft/class_389;
+	FIELD field_983 ENABLED Lnet/minecraft/class_388;
 	METHOD method_880 updateEnabled (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+	CLASS 1
+		METHOD apply (Ljava/lang/Object;)Z
+			ARG 1 dir

--- a/mappings/net/minecraft/block/HorizontalFacingBlock.mapping
+++ b/mappings/net/minecraft/block/HorizontalFacingBlock.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_188 net/minecraft/block/HorizontalFacingBlock
+	FIELD field_852 FACING Lnet/minecraft/class_389;

--- a/mappings/net/minecraft/block/InfestedBlock.mapping
+++ b/mappings/net/minecraft/block/InfestedBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_248 net/minecraft/block/InfestedBlock
+	FIELD field_1040 VARIANT Lnet/minecraft/class_390;
 	CLASS class_249 Variants
 		FIELD field_1042 STONE Lnet/minecraft/class_248$class_249;
 		FIELD field_1043 COBBLESTONE Lnet/minecraft/class_248$class_249;

--- a/mappings/net/minecraft/block/JukeboxBlock.mapping
+++ b/mappings/net/minecraft/block/JukeboxBlock.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_237 net/minecraft/block/JukeboxBlock
+	FIELD field_1004 HAS_RECORD Lnet/minecraft/class_388;
 	CLASS class_238 JukeboxBlockEntity

--- a/mappings/net/minecraft/block/LadderBlock.mapping
+++ b/mappings/net/minecraft/block/LadderBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_239 net/minecraft/block/LadderBlock
+	FIELD field_1006 FACING Lnet/minecraft/class_389;

--- a/mappings/net/minecraft/block/Leaves2Block.mapping
+++ b/mappings/net/minecraft/block/Leaves2Block.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_256 net/minecraft/block/Leaves2Block
+	FIELD field_1055 VARIANT Lnet/minecraft/class_390;
+	CLASS 1
+		METHOD apply (Ljava/lang/Object;)Z
+			ARG 1 type

--- a/mappings/net/minecraft/block/LeavesBlock.mapping
+++ b/mappings/net/minecraft/block/LeavesBlock.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_240 net/minecraft/block/LeavesBlock
+	FIELD field_1010 fancyGraphicsStatus Z
+	FIELD field_1011 DECAYABLE Lnet/minecraft/class_388;
+	FIELD field_1012 CHECK_DECAY Lnet/minecraft/class_388;
+	METHOD method_891 getWoodType (I)Lnet/minecraft/class_266$class_267;
+		ARG 1 state

--- a/mappings/net/minecraft/block/LeverBlock.mapping
+++ b/mappings/net/minecraft/block/LeverBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_241 net/minecraft/block/LeverBlock
+	FIELD field_1013 FACING Lnet/minecraft/class_390;
+	FIELD field_1014 POWERED Lnet/minecraft/class_388;
 	CLASS class_242 LeverType
 		FIELD field_1018 DOWN_X Lnet/minecraft/class_241$class_242;
 		FIELD field_1019 EAST Lnet/minecraft/class_241$class_242;
@@ -19,5 +21,8 @@ CLASS net/minecraft/class_241 net/minecraft/block/LeverBlock
 		METHOD method_898 getId ()I
 		METHOD method_899 getById (I)Lnet/minecraft/class_241$class_242;
 			ARG 0 id
+		METHOD method_900 getByDirection (Lnet/minecraft/class_1383;Lnet/minecraft/class_1383;)Lnet/minecraft/class_241$class_242;
+			ARG 0 dir1
+			ARG 1 dir2
 		METHOD method_901 getDirection ()Lnet/minecraft/class_1383;
 		METHOD values ()[Lnet/minecraft/class_241$class_242;

--- a/mappings/net/minecraft/block/Log2Block.mapping
+++ b/mappings/net/minecraft/block/Log2Block.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_257 net/minecraft/block/Log2Block
+	FIELD field_1056 VARIANT Lnet/minecraft/class_390;

--- a/mappings/net/minecraft/block/LogBlock.mapping
+++ b/mappings/net/minecraft/block/LogBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_244 net/minecraft/block/LogBlock
+	FIELD field_1032 LOG_AXIS Lnet/minecraft/class_390;
 	CLASS class_245 Axis
 		FIELD field_1034 X Lnet/minecraft/class_244$class_245;
 		FIELD field_1035 Y Lnet/minecraft/class_244$class_245;

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -43,6 +43,7 @@ CLASS net/minecraft/class_591 net/minecraft/block/Material
 	FIELD field_2216 SNOW Lnet/minecraft/class_591;
 	METHOD <init> (Lnet/minecraft/class_592;)V
 		ARG 1 color
+	METHOD method_1800 hasCollision ()Z
 	METHOD method_1801 isTransluscent ()Z
 	METHOD method_1802 blocksMovement ()Z
 	METHOD method_1804 requiresTool ()Lnet/minecraft/class_591;

--- a/mappings/net/minecraft/block/MyceliumBlock.mapping
+++ b/mappings/net/minecraft/block/MyceliumBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_252 net/minecraft/block/MyceliumBlock
+	FIELD field_1053 SNOWY Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/NetherPortalBlock.mapping
+++ b/mappings/net/minecraft/block/NetherPortalBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_268 net/minecraft/block/NetherPortalBlock
+	FIELD field_1085 AXIS Lnet/minecraft/class_390;
 	CLASS class_269 AreaHelper
 		FIELD field_1090 foundPortalBlocks I
 		FIELD field_1092 height I

--- a/mappings/net/minecraft/block/NetherWartBlock.mapping
+++ b/mappings/net/minecraft/block/NetherWartBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_254 net/minecraft/block/NetherWartBlock
+	FIELD field_1054 AGE Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/NoteBlock.mapping
+++ b/mappings/net/minecraft/block/NoteBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_260 net/minecraft/block/NoteBlock
+	FIELD field_1067 TUNES Ljava/util/List;

--- a/mappings/net/minecraft/block/PaneBlock.mapping
+++ b/mappings/net/minecraft/block/PaneBlock.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_325 net/minecraft/block/PaneBlock
+	FIELD field_1270 EAST Lnet/minecraft/class_388;
+	FIELD field_1271 SOUTH Lnet/minecraft/class_388;
+	FIELD field_1272 WEST Lnet/minecraft/class_388;
+	FIELD field_1274 NORTH Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/PistonBlock.mapping
+++ b/mappings/net/minecraft/block/PistonBlock.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_369 net/minecraft/block/PistonBlock
 	FIELD field_1471 isSticky Z
 	FIELD field_1472 DIRECTION Lnet/minecraft/class_389;
+	FIELD field_1473 EXTENDED Lnet/minecraft/class_388;
 	METHOD method_1192 shouldExtend (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_1383;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/PistonExtensionBlock.mapping
+++ b/mappings/net/minecraft/block/PistonExtensionBlock.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_373 net/minecraft/block/PistonExtensionBlock
+	FIELD field_1491 FACING Lnet/minecraft/class_389;
+	FIELD field_1492 TYPE Lnet/minecraft/class_390;

--- a/mappings/net/minecraft/block/PistonHeadBlock.mapping
+++ b/mappings/net/minecraft/block/PistonHeadBlock.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_370 net/minecraft/block/PistonHeadBlock
+	FIELD field_1475 SHORT Lnet/minecraft/class_388;
+	FIELD field_1476 FACING Lnet/minecraft/class_389;
+	FIELD field_1477 TYPE Lnet/minecraft/class_390;
 	CLASS class_371 PistonHeadType
 		FIELD field_1479 DEFAULT Lnet/minecraft/class_370$class_371;
 		FIELD field_1480 STICKY Lnet/minecraft/class_370$class_371;

--- a/mappings/net/minecraft/block/PoweredRailBlock.mapping
+++ b/mappings/net/minecraft/block/PoweredRailBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_272 net/minecraft/block/PoweredRailBlock
+	FIELD field_1094 POWERED Lnet/minecraft/class_388;
+	FIELD field_1095 SHAPE Lnet/minecraft/class_390;
 	METHOD method_950 isPoweredByOtherRails (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;ZI)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/PrismarineBlock.mapping
+++ b/mappings/net/minecraft/block/PrismarineBlock.mapping
@@ -19,3 +19,4 @@ CLASS net/minecraft/class_275 net/minecraft/block/PrismarineBlock
 		METHOD method_954 getById (I)Lnet/minecraft/class_275$class_276;
 			ARG 0 id
 		METHOD method_955 getStateName ()Ljava/lang/String;
+		METHOD values ()[Lnet/minecraft/class_275$class_276;

--- a/mappings/net/minecraft/block/RedSandstoneBlock.mapping
+++ b/mappings/net/minecraft/block/RedSandstoneBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_282 net/minecraft/block/RedSandstoneBlock
+	FIELD field_1133 TYPE Lnet/minecraft/class_390;
 	CLASS class_283 RedSandstoneType
 		FIELD field_1134 DEFAULT Lnet/minecraft/class_282$class_283;
 		FIELD field_1135 CHISELED Lnet/minecraft/class_282$class_283;
@@ -15,3 +16,4 @@ CLASS net/minecraft/class_282 net/minecraft/block/RedSandstoneBlock
 		METHOD method_966 getById (I)Lnet/minecraft/class_282$class_283;
 			ARG 0 id
 		METHOD method_967 getBlockStateName ()Ljava/lang/String;
+		METHOD values ()[Lnet/minecraft/class_282$class_283;

--- a/mappings/net/minecraft/block/RedSandstoneSlabBlock.mapping
+++ b/mappings/net/minecraft/block/RedSandstoneSlabBlock.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_258 net/minecraft/block/RedSandstoneSlabBlock
+	FIELD field_1059 VARIANT Lnet/minecraft/class_390;
+	FIELD field_1060 SEAMLESS Lnet/minecraft/class_388;
 	CLASS class_259 SlabType
 		FIELD field_1061 RED_SANDSTONE Lnet/minecraft/class_258$class_259;
 		FIELD field_1062 TYPES [Lnet/minecraft/class_258$class_259;

--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -1,6 +1,11 @@
 CLASS net/minecraft/class_286 net/minecraft/block/RedstoneWireBlock
+	FIELD field_1143 SOUTH Lnet/minecraft/class_390;
+	FIELD field_1144 WEST Lnet/minecraft/class_390;
+	FIELD field_1145 POWER Lnet/minecraft/class_391;
 	FIELD field_1146 wiresGivePower Z
 	FIELD field_1147 affectedNeighbors Ljava/util/Set;
+	FIELD field_1148 NORTH Lnet/minecraft/class_390;
+	FIELD field_1149 EAST Lnet/minecraft/class_390;
 	METHOD method_973 connectsTo (Lnet/minecraft/class_376;Lnet/minecraft/class_1383;)Z
 		ARG 0 state
 		ARG 1 dir

--- a/mappings/net/minecraft/block/RepeaterBlock.mapping
+++ b/mappings/net/minecraft/block/RepeaterBlock.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_292 net/minecraft/block/RepeaterBlock
+	FIELD field_1161 LOCKED Lnet/minecraft/class_388;
+	FIELD field_1162 DELAY Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/SandBlock.mapping
+++ b/mappings/net/minecraft/block/SandBlock.mapping
@@ -17,3 +17,4 @@ CLASS net/minecraft/class_294 net/minecraft/block/SandBlock
 			ARG 0 id
 		METHOD method_987 getColor ()Lnet/minecraft/class_592;
 		METHOD method_988 getTranslationKey ()Ljava/lang/String;
+		METHOD values ()[Lnet/minecraft/class_294$class_295;

--- a/mappings/net/minecraft/block/SaplingBlock.mapping
+++ b/mappings/net/minecraft/block/SaplingBlock.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_298 net/minecraft/block/SaplingBlock
+	FIELD field_1182 TYPE Lnet/minecraft/class_390;
+	FIELD field_1183 STAGE Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/SkeletonSkullBlock.mapping
+++ b/mappings/net/minecraft/block/SkeletonSkullBlock.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_301 net/minecraft/block/SkeletonSkullBlock
-	FIELD field_1188 direction Lnet/minecraft/class_389;
+	FIELD field_1188 FACING Lnet/minecraft/class_389;
+	FIELD field_1189 NO_DROP Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/SlabBlock.mapping
+++ b/mappings/net/minecraft/block/SlabBlock.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_226 net/minecraft/block/SlabBlock
+	FIELD field_976 HALD Lnet/minecraft/class_390;
 	METHOD method_877 isDoubleSlab ()Z
-	CLASS class_227
+	CLASS class_227 SlabType
 		FIELD field_977 TOP Lnet/minecraft/class_226$class_227;
 		FIELD field_978 BOTTOM Lnet/minecraft/class_226$class_227;
 		FIELD field_979 name Ljava/lang/String;

--- a/mappings/net/minecraft/block/SnowLayerBlock.mapping
+++ b/mappings/net/minecraft/block/SnowLayerBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_304 net/minecraft/block/SnowLayerBlock
+	FIELD field_1191 LAYERS Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/SpongeBlock.mapping
+++ b/mappings/net/minecraft/block/SpongeBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_306 net/minecraft/block/SpongeBlock
+	FIELD field_1192 WET Lnet/minecraft/class_388;
 	METHOD method_1003 absorbWater (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/StainedGlassBlock.mapping
+++ b/mappings/net/minecraft/block/StainedGlassBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_307 net/minecraft/block/StainedGlassBlock
+	FIELD field_1193 COLOR Lnet/minecraft/class_390;

--- a/mappings/net/minecraft/block/StainedGlassPaneBlock.mapping
+++ b/mappings/net/minecraft/block/StainedGlassPaneBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_308 net/minecraft/block/StainedGlassPaneBlock
+	FIELD field_1194 COLOR Lnet/minecraft/class_390;

--- a/mappings/net/minecraft/block/SugarCaneBlock.mapping
+++ b/mappings/net/minecraft/block/SugarCaneBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_291 net/minecraft/block/SugarCaneBlock
+	FIELD field_1160 AGE Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/TallPlantBlock.mapping
+++ b/mappings/net/minecraft/block/TallPlantBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_323 net/minecraft/block/TallPlantBlock
+	FIELD field_1262 TYPE Lnet/minecraft/class_390;
 	CLASS class_324 GrassType
 		FIELD field_1263 DEAD_BUSH Lnet/minecraft/class_323$class_324;
 		FIELD field_1264 GRASS Lnet/minecraft/class_323$class_324;

--- a/mappings/net/minecraft/block/TntBlock.mapping
+++ b/mappings/net/minecraft/block/TntBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_326 net/minecraft/block/TntBlock
+	FIELD field_1275 EXPLODE Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/TrapdoorBlock.mapping
+++ b/mappings/net/minecraft/block/TrapdoorBlock.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_329 net/minecraft/block/TrapdoorBlock
+	FIELD field_1279 HALF Lnet/minecraft/class_390;
+	FIELD field_1280 FACING Lnet/minecraft/class_389;
+	FIELD field_1281 OPEN Lnet/minecraft/class_388;
 	CLASS class_330 TrapdoorType
 		FIELD field_1283 TOP Lnet/minecraft/class_329$class_330;
 		FIELD field_1284 BOTTOM Lnet/minecraft/class_329$class_330;

--- a/mappings/net/minecraft/block/TripwireBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireBlock.mapping
@@ -1,8 +1,16 @@
 CLASS net/minecraft/class_331 net/minecraft/block/TripwireBlock
+	FIELD field_1287 ATTACHED Lnet/minecraft/class_388;
+	FIELD field_1288 DISARMED Lnet/minecraft/class_388;
+	FIELD field_1289 NORTH Lnet/minecraft/class_388;
+	FIELD field_1290 EAST Lnet/minecraft/class_388;
+	FIELD field_1291 SOUTH Lnet/minecraft/class_388;
+	FIELD field_1292 WEST Lnet/minecraft/class_388;
+	FIELD field_1293 POWERED Lnet/minecraft/class_388;
+	FIELD field_1294 SUSPENDED Lnet/minecraft/class_388;
+	METHOD method_1045 updatePowered (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)V
+		ARG 1 world
+		ARG 2 pos
 	METHOD method_1046 update (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;Lnet/minecraft/class_376;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD method_1045 updatePowered (Lnet/minecraft/class_99;Lnet/minecraft/class_1372;)V
-		ARG 1 world
-		ARG 2 pos

--- a/mappings/net/minecraft/block/TripwireHookBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireHookBlock.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_332 net/minecraft/block/TripwireHookBlock
+	FIELD field_1295 ATTACHED Lnet/minecraft/class_388;
+	FIELD field_1296 SUSPENDED Lnet/minecraft/class_388;
+	FIELD field_1297 FACING Lnet/minecraft/class_389;
+	FIELD field_1298 POWERED Lnet/minecraft/class_388;

--- a/mappings/net/minecraft/block/VineBlock.mapping
+++ b/mappings/net/minecraft/block/VineBlock.mapping
@@ -1,1 +1,11 @@
 CLASS net/minecraft/class_333 net/minecraft/block/VineBlock
+	FIELD field_1300 EAST Lnet/minecraft/class_388;
+	FIELD field_1301 SOUTH Lnet/minecraft/class_388;
+	FIELD field_1302 WEST Lnet/minecraft/class_388;
+	FIELD field_1303 PROPERTIES [Lnet/minecraft/class_388;
+	FIELD field_1304 UP Lnet/minecraft/class_388;
+	FIELD field_1305 NORTH Lnet/minecraft/class_388;
+	METHOD method_1051 getByDirection (Lnet/minecraft/class_1383;)Lnet/minecraft/class_388;
+		ARG 0 dir
+	METHOD method_1053 getBlockStateId (Lnet/minecraft/class_376;)I
+		ARG 0 state

--- a/mappings/net/minecraft/block/WallBlock.mapping
+++ b/mappings/net/minecraft/block/WallBlock.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/class_334 net/minecraft/block/WallBlock
+	FIELD field_1307 EAST Lnet/minecraft/class_388;
+	FIELD field_1308 SOUTH Lnet/minecraft/class_388;
+	FIELD field_1309 WEST Lnet/minecraft/class_388;
+	FIELD field_1310 VARIANT Lnet/minecraft/class_390;
+	FIELD field_1311 UP Lnet/minecraft/class_388;
+	FIELD field_1312 NORTH Lnet/minecraft/class_388;
 	CLASS class_335 WallType
 		FIELD field_1313 NORMAL Lnet/minecraft/class_334$class_335;
 		FIELD field_1314 MOSSY Lnet/minecraft/class_334$class_335;
@@ -14,4 +20,3 @@ CLASS net/minecraft/class_334 net/minecraft/block/WallBlock
 		METHOD method_1057 getById (I)Lnet/minecraft/class_334$class_335;
 			ARG 0 id
 		METHOD method_1058 getBlockStateName ()Ljava/lang/String;
-		METHOD values ()[Lnet/minecraft/class_334$class_335;

--- a/mappings/net/minecraft/block/WallSignBlock.mapping
+++ b/mappings/net/minecraft/block/WallSignBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_336 net/minecraft/block/WallSignBlock
+	FIELD field_1320 FACING Lnet/minecraft/class_389;

--- a/mappings/net/minecraft/block/WeightedPressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/WeightedPressurePlateBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_339 net/minecraft/block/WeightedPressurePlateBlock
+	FIELD field_1322 POWER Lnet/minecraft/class_391;

--- a/mappings/net/minecraft/block/WoodSlabBlock.mapping
+++ b/mappings/net/minecraft/block/WoodSlabBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_341 net/minecraft/block/WoodSlabBlock
+	FIELD field_1324 VARIANT Lnet/minecraft/class_390;

--- a/mappings/net/minecraft/class_1515.mapping
+++ b/mappings/net/minecraft/class_1515.mapping
@@ -1,6 +1,0 @@
-CLASS net/minecraft/class_1515
-	METHOD method_5554 (Lnet/minecraft/class_1659;Lnet/minecraft/class_1606;ILjava/lang/String;[Ljava/lang/Object;)V
-		ARG 1 sender
-		ARG 2 command
-		ARG 4 label
-		ARG 5 args

--- a/mappings/net/minecraft/class_818.mapping
+++ b/mappings/net/minecraft/class_818.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_818

--- a/mappings/net/minecraft/command/CommandProvider.mapping
+++ b/mappings/net/minecraft/command/CommandProvider.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/class_1515 net/minecraft/command/CommandProvider
+	METHOD method_5554 run (Lnet/minecraft/class_1659;Lnet/minecraft/class_1606;ILjava/lang/String;[Ljava/lang/Object;)V
+		ARG 1 sender
+		ARG 2 command
+		ARG 3 permissionLevel
+		ARG 4 label
+		ARG 5 args

--- a/mappings/net/minecraft/enchantment/Enchantment.mapping
+++ b/mappings/net/minecraft/enchantment/Enchantment.mapping
@@ -1,6 +1,40 @@
 CLASS net/minecraft/class_64 net/minecraft/enchantment/Enchantment
+	FIELD field_112 LURE Lnet/minecraft/class_64;
+	FIELD field_113 id I
+	FIELD field_114 target Lnet/minecraft/class_65;
 	FIELD field_115 translationKey Ljava/lang/String;
+	FIELD field_116 ENCHANTMENT_MAP Ljava/util/Map;
+	FIELD field_117 enchantmentType I
+	FIELD field_118 ENCHANTMENTS [Lnet/minecraft/class_64;
+	FIELD field_119 ALL_ENCHANTMENTS [Lnet/minecraft/class_64;
+	FIELD field_120 PROTECTION Lnet/minecraft/class_64;
+	FIELD field_121 FIRE_PROTECTION Lnet/minecraft/class_64;
+	FIELD field_122 FEATHER_FALLING Lnet/minecraft/class_64;
+	FIELD field_123 BLAST_PROTECTION Lnet/minecraft/class_64;
+	FIELD field_124 PROJECTILE_PROTECTION Lnet/minecraft/class_64;
+	FIELD field_125 RESPIRATION Lnet/minecraft/class_64;
+	FIELD field_126 AQUA_AFFINITY Lnet/minecraft/class_64;
+	FIELD field_127 THORNS Lnet/minecraft/class_64;
+	FIELD field_128 DEPTH_STRIDER Lnet/minecraft/class_64;
+	FIELD field_129 SHARPNESS Lnet/minecraft/class_64;
+	FIELD field_130 SMITE Lnet/minecraft/class_64;
+	FIELD field_131 BANE_OF_ARTHROPODS Lnet/minecraft/class_64;
+	FIELD field_132 KNOCKBACK Lnet/minecraft/class_64;
+	FIELD field_133 FIRE_ASPECT Lnet/minecraft/class_64;
+	FIELD field_134 LOOTING Lnet/minecraft/class_64;
+	FIELD field_135 EFFICIENCY Lnet/minecraft/class_64;
+	FIELD field_136 SILK_TOUCH Lnet/minecraft/class_64;
+	FIELD field_137 UNBREAKING Lnet/minecraft/class_64;
+	FIELD field_138 FORTUNE Lnet/minecraft/class_64;
+	FIELD field_139 POWER Lnet/minecraft/class_64;
+	FIELD field_140 PUNCH Lnet/minecraft/class_64;
+	FIELD field_141 FLAME Lnet/minecraft/class_64;
+	FIELD field_142 INIFINITY Lnet/minecraft/class_64;
+	FIELD field_143 LUCK_OF_THE_SEA Lnet/minecraft/class_64;
 	METHOD <init> (ILnet/minecraft/class_1605;ILnet/minecraft/class_65;)V
+		ARG 1 id
+		ARG 2 identifier
+		ARG 3 enchantmentType
 		ARG 4 target
 	METHOD method_79 getTranslationKey ()Ljava/lang/String;
 	METHOD method_80 getMinimumPower (I)I
@@ -8,17 +42,30 @@ CLASS net/minecraft/class_64 net/minecraft/enchantment/Enchantment
 	METHOD method_81 getProtectionAmount (ILnet/minecraft/class_1733;)I
 		ARG 1 level
 		ARG 2 source
-	METHOD method_82 (ILnet/minecraft/class_1758;)F
+	METHOD method_82 getDamageModifier (ILnet/minecraft/class_1758;)F
 		ARG 1 index
 		ARG 2 target
 	METHOD method_83 differs (Lnet/minecraft/class_64;)Z
 		ARG 1 other
+	METHOD method_84 (Lnet/minecraft/class_1752;Lnet/minecraft/class_1745;I)V
+		ARG 1 livingEntity
+		ARG 2 entity
 	METHOD method_85 isAcceptableItem (Lnet/minecraft/class_2056;)Z
 		ARG 1 stack
 	METHOD method_86 getMaximumLevel ()I
 	METHOD method_87 getMaximumPower (I)I
 		ARG 1 level
+	METHOD method_88 getByName (Ljava/lang/String;)Lnet/minecraft/class_64;
+		ARG 0 name
+	METHOD method_89 (Lnet/minecraft/class_1752;Lnet/minecraft/class_1745;I)V
+		ARG 1 livingEntity
+		ARG 2 entity
+	METHOD method_90 getSet ()Ljava/util/Set;
 	METHOD method_91 byRawId (I)Lnet/minecraft/class_64;
 		ARG 0 id
 	METHOD method_92 setName (Ljava/lang/String;)Lnet/minecraft/class_64;
+		ARG 1 translationKey
+	METHOD method_93 getEnchantmentType ()I
+	METHOD method_94 getTranslatedName (I)Ljava/lang/String;
+		ARG 1 level
 	METHOD method_95 getMinimumLevel ()I

--- a/mappings/net/minecraft/enchantment/EnchantmentInfo.mapping
+++ b/mappings/net/minecraft/enchantment/EnchantmentInfo.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_72 net/minecraft/enchantment/EnchantmentInfo
+	FIELD field_169 enchantment Lnet/minecraft/class_64;
+	FIELD field_170 level I
+	METHOD <init> (Lnet/minecraft/class_64;I)V
+		ARG 1 enchantment
+		ARG 2 level

--- a/mappings/net/minecraft/enchantment/InfoEnchantment.mapping
+++ b/mappings/net/minecraft/enchantment/InfoEnchantment.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_72 net/minecraft/enchantment/InfoEnchantment
-	FIELD field_170 level I

--- a/mappings/net/minecraft/server/command/Console.mapping
+++ b/mappings/net/minecraft/server/command/Console.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_1669 net/minecraft/server/command/Console
+	FIELD field_6844 INSTANCE Lnet/minecraft/class_1669;
+	METHOD method_6303 getInstance ()Lnet/minecraft/class_1669;

--- a/mappings/net/minecraft/state/property/AbstractProperty.mapping
+++ b/mappings/net/minecraft/state/property/AbstractProperty.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_387 net/minecraft/state/property/AbstractProperty
 	FIELD field_1538 type Ljava/lang/Class;
 	FIELD field_1539 name Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;Ljava/lang/Class;)V
+		ARG 1 name
+		ARG 2 type
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 obj

--- a/mappings/net/minecraft/state/property/EnumProperty.mapping
+++ b/mappings/net/minecraft/state/property/EnumProperty.mapping
@@ -1,6 +1,17 @@
 CLASS net/minecraft/class_390 net/minecraft/state/property/EnumProperty
 	FIELD field_1541 values Lcom/google/common/collect/ImmutableSet;
 	FIELD field_1542 byName Ljava/util/Map;
+	METHOD <init> (Ljava/lang/String;Ljava/lang/Class;Ljava/util/Collection;)V
+		ARG 1 name
+		ARG 2 clazz
+		ARG 3 values
+	METHOD method_1272 of (Ljava/lang/String;Ljava/lang/Class;)Lnet/minecraft/class_390;
+		ARG 0 name
+		ARG 1 type
+	METHOD method_1273 of (Ljava/lang/String;Ljava/lang/Class;Lcom/google/common/base/Predicate;)Lnet/minecraft/class_390;
+		ARG 0 name
+		ARG 1 type
+		ARG 2 pred
 	METHOD method_1274 of (Ljava/lang/String;Ljava/lang/Class;Ljava/util/Collection;)Lnet/minecraft/class_390;
 		ARG 0 name
 		ARG 1 type
@@ -9,6 +20,3 @@ CLASS net/minecraft/class_390 net/minecraft/state/property/EnumProperty
 		ARG 0 name
 		ARG 1 type
 		ARG 2 values
-	METHOD method_1272 of (Ljava/lang/String;Ljava/lang/Class;)Lnet/minecraft/class_390;
-		ARG 0 name
-		ARG 1 type

--- a/mappings/net/minecraft/state/property/IntProperty.mapping
+++ b/mappings/net/minecraft/state/property/IntProperty.mapping
@@ -1,5 +1,9 @@
 CLASS net/minecraft/class_391 net/minecraft/state/property/IntProperty
 	FIELD field_1543 values Lcom/google/common/collect/ImmutableSet;
+	METHOD <init> (Ljava/lang/String;II)V
+		ARG 1 name
+		ARG 2 min
+		ARG 3 max
 	METHOD method_1277 of (Ljava/lang/String;II)Lnet/minecraft/class_391;
 		ARG 0 name
 		ARG 1 min

--- a/mappings/net/minecraft/world/level/LevelProperties.mapping
+++ b/mappings/net/minecraft/world/level/LevelProperties.mapping
@@ -148,3 +148,13 @@ CLASS net/minecraft/class_634 net/minecraft/world/level/LevelProperties
 	METHOD method_1997 getGamerules ()Lnet/minecraft/class_95;
 	METHOD method_1998 getDifficulty ()Lnet/minecraft/class_1721;
 	METHOD method_1999 isDifficultyLocked ()Z
+	CLASS 5
+		METHOD call ()Ljava/lang/Object;
+	CLASS 6
+		METHOD call ()Ljava/lang/Object;
+	CLASS 7
+		METHOD call ()Ljava/lang/Object;
+	CLASS 8
+		METHOD call ()Ljava/lang/Object;
+	CLASS 9
+		METHOD call ()Ljava/lang/Object;


### PR DESCRIPTION
Surprisingly, enchantment constants weren't mapped even though I spent quite a bit of time mapping the methods. 
Also mapped every single block state property and some command related classes and fields.

There was also a class that someone(not me) had mapped that looked cursed
![image](https://user-images.githubusercontent.com/62552372/86379812-ee7e3e80-bca8-11ea-9128-79fb6f4758b8.png)


Changelog:-
```ruby
 On branch 1.8.9-dev7
 Changes to be committed:
	modified:   mappings/net/minecraft/enchantment/Enchantment.mapping
	new file:   mappings/net/minecraft/enchantment/EnchantmentInfo.mapping
	deleted:    mappings/net/minecraft/enchantment/InfoEnchantment.mapping
	modified:   mappings/net/minecraft/block/AbstractFluidBlock.mapping
	modified:   mappings/net/minecraft/block/AttachedStemBlock.mapping
	new file:   mappings/net/minecraft/block/BaseLeavesBlock.mapping
	modified:   mappings/net/minecraft/block/Block.mapping
	modified:   mappings/net/minecraft/block/FireBlock.mapping
	modified:   mappings/net/minecraft/block/FurnaceBlock.mapping
	modified:   mappings/net/minecraft/block/HopperBlock.mapping
	modified:   mappings/net/minecraft/block/LadderBlock.mapping
	modified:   mappings/net/minecraft/block/Leaves2Block.mapping
	modified:   mappings/net/minecraft/block/LeavesBlock.mapping
	modified:   mappings/net/minecraft/block/Material.mapping
	modified:   mappings/net/minecraft/block/VineBlock.mapping
	modified:   mappings/net/minecraft/state/property/AbstractProperty.mapping
	modified:   mappings/net/minecraft/state/property/EnumProperty.mapping
	modified:   mappings/net/minecraft/state/property/IntProperty.mapping
	modified:   mappings/net/minecraft/block/AbstractButtonBlock.mapping
	modified:   mappings/net/minecraft/block/AbstractRailBlock.mapping
	modified:   mappings/net/minecraft/block/AnvilBlock.mapping
	modified:   mappings/net/minecraft/block/BigMushroomBlock.mapping
	modified:   mappings/net/minecraft/block/BlockEntityProvider.mapping
	modified:   mappings/net/minecraft/block/BrewingStandBlock.mapping
	modified:   mappings/net/minecraft/block/CactusBlock.mapping
	modified:   mappings/net/minecraft/block/CarpetBlock.mapping
	modified:   mappings/net/minecraft/block/CauldronBlock.mapping
	modified:   mappings/net/minecraft/block/ChestBlock.mapping
	modified:   mappings/net/minecraft/block/ComparatorBlock.mapping
	deleted:    mappings/net/minecraft/block/ConcretePowderBlock.mapping
	modified:   mappings/net/minecraft/block/DispenserBlock.mapping
	modified:   mappings/net/minecraft/block/DoorBlock.mapping
	modified:   mappings/net/minecraft/block/EndPortalFrameBlock.mapping
	modified:   mappings/net/minecraft/block/EnderChestBlock.mapping
	deleted:    mappings/net/minecraft/block/FacingBlock.mapping
	modified:   mappings/net/minecraft/block/FenceBlock.mapping
	modified:   mappings/net/minecraft/block/FenceGateBlock.mapping
	modified:   mappings/net/minecraft/block/FlowerPotBlock.mapping
	modified:   mappings/net/minecraft/block/GrassBlock.mapping
	new file:   mappings/net/minecraft/block/HorizontalFacingBlock.mapping
	modified:   mappings/net/minecraft/block/InfestedBlock.mapping
	modified:   mappings/net/minecraft/block/JukeboxBlock.mapping
	modified:   mappings/net/minecraft/block/LeverBlock.mapping
	modified:   mappings/net/minecraft/block/Log2Block.mapping
	modified:   mappings/net/minecraft/block/LogBlock.mapping
	modified:   mappings/net/minecraft/block/MyceliumBlock.mapping
	modified:   mappings/net/minecraft/block/NetherPortalBlock.mapping
	modified:   mappings/net/minecraft/block/NetherWartBlock.mapping
	modified:   mappings/net/minecraft/block/NoteBlock.mapping
	modified:   mappings/net/minecraft/block/PaneBlock.mapping
	modified:   mappings/net/minecraft/block/PistonBlock.mapping
	modified:   mappings/net/minecraft/block/PistonExtensionBlock.mapping
	modified:   mappings/net/minecraft/block/PistonHeadBlock.mapping
	modified:   mappings/net/minecraft/block/PoweredRailBlock.mapping
	modified:   mappings/net/minecraft/block/PrismarineBlock.mapping
	modified:   mappings/net/minecraft/block/RedSandstoneBlock.mapping
	modified:   mappings/net/minecraft/block/RedSandstoneSlabBlock.mapping
	modified:   mappings/net/minecraft/block/RedstoneWireBlock.mapping
	modified:   mappings/net/minecraft/block/RepeaterBlock.mapping
	modified:   mappings/net/minecraft/block/SandBlock.mapping
	modified:   mappings/net/minecraft/block/SaplingBlock.mapping
	modified:   mappings/net/minecraft/block/SkeletonSkullBlock.mapping
	modified:   mappings/net/minecraft/block/SlabBlock.mapping
	modified:   mappings/net/minecraft/block/SnowLayerBlock.mapping
	modified:   mappings/net/minecraft/block/SpongeBlock.mapping
	modified:   mappings/net/minecraft/block/StainedGlassBlock.mapping
	modified:   mappings/net/minecraft/block/StainedGlassPaneBlock.mapping
	modified:   mappings/net/minecraft/block/SugarCaneBlock.mapping
	modified:   mappings/net/minecraft/block/TallPlantBlock.mapping
	modified:   mappings/net/minecraft/block/TntBlock.mapping
	modified:   mappings/net/minecraft/block/TrapdoorBlock.mapping
	modified:   mappings/net/minecraft/block/TripwireBlock.mapping
	modified:   mappings/net/minecraft/block/TripwireHookBlock.mapping
	modified:   mappings/net/minecraft/block/WallBlock.mapping
	modified:   mappings/net/minecraft/block/WallSignBlock.mapping
	modified:   mappings/net/minecraft/block/WeightedPressurePlateBlock.mapping
	modified:   mappings/net/minecraft/block/WoodSlabBlock.mapping
	new file:   mappings/net/minecraft/class_818.mapping
	deleted:    mappings/net/minecraft/class_1515.mapping
	new file:   mappings/net/minecraft/command/CommandProvider.mapping
	new file:   mappings/net/minecraft/server/command/Console.mapping
	modified:   mappings/net/minecraft/world/level/LevelProperties.mapping
```