### PR TITLE
Advanced OpenGl and Entities' models and renderers

### DIFF
--- a/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlHelper.mapping
+++ b/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlHelper.mapping
@@ -1,6 +1,0 @@
-CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlHelper
-	FIELD field_5725 nvidia Z
-	FIELD field_5728 amd Z
-	FIELD field_5729 framebuffer I
-	FIELD field_5730 renderbuffer I
-	METHOD method_4789 createContext ()V

--- a/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
@@ -1,0 +1,136 @@
+CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlManager
+	FIELD field_5712 gl21Context Z
+	FIELD field_5714 gl15 Z
+	FIELD field_5718 advancedOpenGlType I
+	FIELD field_5719 gl21 Z
+	FIELD field_5720 arbShaderObjects Z
+	FIELD field_5721 arbMultitexture Z
+	FIELD field_5722 arbTextureEnvCombine Z
+	FIELD field_5723 gl14Context Z
+	FIELD field_5724 contextDescription Ljava/lang/String;
+	FIELD field_5725 nvidia Z
+	FIELD field_5727 gl15Context Z
+	FIELD field_5728 amd Z
+	FIELD field_5729 framebuffer I
+	FIELD field_5730 renderbuffer I
+	FIELD field_5738 gl14 Z
+	METHOD method_4789 createContext ()V
+	METHOD method_4790 gl20DeleteShader (I)V
+		ARG 0 shader
+	METHOD method_4791 gl13MultiTexCoord2f (IFF)V
+		ARG 0 i
+		ARG 1 f1
+		ARG 2 f2
+	METHOD method_4792 gl20GetProgrami (II)I
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4793 gl30RenderBufferStorage (IIII)V
+	METHOD method_4794 gl30FrameBufferTexture2D (IIIII)V
+	METHOD method_4795 gl20GetUniformLocation (ILjava/lang/CharSequence;)I
+		ARG 0 loc
+		ARG 1 sequence
+	METHOD method_4796 gl20ShaderSource (ILjava/nio/ByteBuffer;)V
+		ARG 0 shader
+		ARG 1 buf
+	METHOD method_4797 gl15BufferData (ILjava/nio/ByteBuffer;I)V
+		ARG 0 i
+		ARG 1 buf
+		ARG 2 j
+	METHOD method_4798 gl20Uniform (ILjava/nio/FloatBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4799 gl20Uniform1 (ILjava/nio/IntBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4800 gl20UniformMatrix2 (IZLjava/nio/FloatBuffer;)V
+		ARG 0 uniform
+		ARG 1 bl
+		ARG 2 buf
+	METHOD method_4802 gl20CreateShader (I)I
+		ARG 0 shader
+	METHOD method_4803 gl20GetAttachShader (II)V
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4804 gl30FramebufferRenderbuffer (IIII)V
+	METHOD method_4805 gl20GetAttribLocation (ILjava/lang/CharSequence;)I
+		ARG 0 loc
+		ARG 1 sequence
+	METHOD method_4806 gl20Uniform2 (ILjava/nio/FloatBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4807 gl20Uniform2 (ILjava/nio/IntBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4808 gl20UniformMatrix3 (IZLjava/nio/FloatBuffer;)V
+		ARG 0 uniform
+		ARG 1 bl
+		ARG 2 buf
+	METHOD method_4809 getContextDescription ()Ljava/lang/String;
+	METHOD method_4810 gl20CompileShader (I)V
+		ARG 0 shader
+	METHOD method_4811 gl20GetShaderi (II)I
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4812 gl14BlendFuncSeperate (IIII)V
+		ARG 0 r
+		ARG 1 g
+		ARG 2 b
+		ARG 3 a
+	METHOD method_4813 gl20Uniform3 (ILjava/nio/FloatBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4814 gl20Uniform3 (ILjava/nio/IntBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4815 gl20UniformMatrix4 (IZLjava/nio/FloatBuffer;)V
+		ARG 0 uniform
+		ARG 1 bl
+		ARG 2 buf
+	METHOD method_4816 gl20CreateProgram ()I
+	METHOD method_4817 gl20UseProgram (I)V
+		ARG 0 program
+	METHOD method_4818 gl20GetShaderInfoLog (II)Ljava/lang/String;
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4819 gl20Uniform4 (ILjava/nio/FloatBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4820 gl20Uniform4 (ILjava/nio/IntBuffer;)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4821 gl15GenBuffers ()I
+	METHOD method_4822 gl20DeleteProgram (I)V
+		ARG 0 program
+	METHOD method_4823 gl20GetProgramInfoLog (II)Ljava/lang/String;
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4824 supportsVbo ()Z
+	METHOD method_4825 gl20LinkProgram (I)V
+		ARG 0 program
+	METHOD method_4826 gl20Uniform1 (II)V
+		ARG 0 uniform
+		ARG 1 buf
+	METHOD method_4827 gl30GenFrameBuffers ()I
+	METHOD method_4828 gl15DeleteBuffers (I)V
+		ARG 0 i
+	METHOD method_4829 gl15BindBuffer (II)V
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4830 gl30GenRenderBuffers ()I
+	METHOD method_4831 gl30DeleteRenderBuffers (I)V
+		ARG 0 renderbuffer
+	METHOD method_4832 gl30BindFramebuffer (II)V
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4833 supportsFbo ()Z
+	METHOD method_4834 gl30DeleteFrameBuffers (I)V
+		ARG 0 framebuffer
+	METHOD method_4835 gl30BindRenderBuffer (II)V
+		ARG 0 i
+		ARG 1 j
+	METHOD method_4837 gl30CheckFrameBufferStatus (I)I
+		ARG 0 framebuffer
+	METHOD method_4838 gl13ActiveTexture (I)V
+		ARG 0 texture
+	METHOD method_4839 gl13ClientActiveTexture (I)V
+		ARG 0 texture

--- a/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
@@ -17,121 +17,167 @@ CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlManager
 	FIELD field_5738 gl14 Z
 	METHOD method_4789 createContext ()V
 	METHOD method_4790 gl20DeleteShader (I)V
+		COMMENT Deletes a shader object
 		ARG 0 shader
 	METHOD method_4791 gl13MultiTexCoord2f (IFF)V
+		COMMENT Sets the current texture coordinates
 		ARG 0 i
 		ARG 1 f1
 		ARG 2 f2
 	METHOD method_4792 gl20GetProgrami (II)I
+		COMMENT Returns a parameter from a program object
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4793 advancedRenderBufferStorage (IIII)V
+		COMMENT Establishes data storage, format and dimensions of a renderbuffer object's image
 	METHOD method_4794 advancedFrameBufferTexture2D (IIIII)V
+		COMMENT Attaches a level of a texture object as a logical buffer of a framebuffer object
 	METHOD method_4795 gl20GetUniformLocation (ILjava/lang/CharSequence;)I
+		COMMENT Returns the location of a uniform variable
 		ARG 0 loc
 		ARG 1 sequence
 	METHOD method_4796 gl20ShaderSource (ILjava/nio/ByteBuffer;)V
+		COMMENT Replaces the source code in a shader object
 		ARG 0 shader
 		ARG 1 buf
 	METHOD method_4797 gl15BufferData (ILjava/nio/ByteBuffer;I)V
+		COMMENT Binds a named buffer object
 		ARG 0 i
 		ARG 1 buf
 		ARG 2 j
 	METHOD method_4798 gl20Uniform (ILjava/nio/FloatBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4799 gl20Uniform1 (ILjava/nio/IntBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4800 gl20UniformMatrix2 (IZLjava/nio/FloatBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 bl
 		ARG 2 buf
 	METHOD method_4802 gl20CreateShader (I)I
+		COMMENT Creates a shader object
 		ARG 0 shader
 	METHOD method_4803 gl20GetAttachShader (II)V
+		COMMENT Attaches a shader object to a program object
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4804 advancedFramebufferRenderbuffer (IIII)V
+		COMMENT Attaches a renderbuffer as a logical buffer of a framebuffer object
 	METHOD method_4805 gl20GetAttribLocation (ILjava/lang/CharSequence;)I
+		COMMENT Returns the location of an attribute variable
 		ARG 0 loc
 		ARG 1 sequence
 	METHOD method_4806 gl20Uniform2 (ILjava/nio/FloatBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4807 gl20Uniform2 (ILjava/nio/IntBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4808 gl20UniformMatrix3 (IZLjava/nio/FloatBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 bl
 		ARG 2 buf
 	METHOD method_4809 getContextDescription ()Ljava/lang/String;
 	METHOD method_4810 gl20CompileShader (I)V
+		COMMENT Compiles a shader object
 		ARG 0 shader
 	METHOD method_4811 gl20GetShaderi (II)I
+		COMMENT Returns a parameter from a shader object
 		ARG 0 i
 		ARG 1 j
-	METHOD method_4812 gl14BlendFuncSeperate (IIII)V
+	METHOD method_4812 blendFuncSeperate (IIII)V
+		COMMENT Specifies pixel arithmetic for RGB and alpha components separately
 		ARG 0 r
 		ARG 1 g
 		ARG 2 b
 		ARG 3 a
 	METHOD method_4813 gl20Uniform3 (ILjava/nio/FloatBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4814 gl20Uniform3 (ILjava/nio/IntBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4815 gl20UniformMatrix4 (IZLjava/nio/FloatBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 bl
 		ARG 2 buf
 	METHOD method_4816 gl20CreateProgram ()I
+		COMMENT Creates a program object
 	METHOD method_4817 gl20UseProgram (I)V
+		COMMENT Installs a program object as part of current rendering state
 		ARG 0 program
 	METHOD method_4818 gl20GetShaderInfoLog (II)Ljava/lang/String;
+		COMMENT Returns the information log for a shader object
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4819 gl20Uniform4 (ILjava/nio/FloatBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4820 gl20Uniform4 (ILjava/nio/IntBuffer;)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4821 gl15GenBuffers ()I
+		COMMENT Generates buffer object names
 	METHOD method_4822 gl20DeleteProgram (I)V
+		COMMENT Deletes a program object
 		ARG 0 program
 	METHOD method_4823 gl20GetProgramInfoLog (II)Ljava/lang/String;
+		COMMENT Returns the information log for a program object
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4824 supportsVbo ()Z
+		COMMENT Returns whether OpenGl supports Vertex Buffer Objects
 	METHOD method_4825 gl20LinkProgram (I)V
+		COMMENT Links a program object
 		ARG 0 program
 	METHOD method_4826 gl20Uniform1 (II)V
+		COMMENT Specifies the value of a uniform variable for the current program object
 		ARG 0 uniform
 		ARG 1 buf
 	METHOD method_4827 advancedGenFrameBuffers ()I
+		COMMENT Generates framebuffer object names
 	METHOD method_4828 gl15DeleteBuffers (I)V
+		COMMENT Deletes named buffer objects
 		ARG 0 i
 	METHOD method_4829 gl15BindBuffer (II)V
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4830 advancedGenRenderBuffers ()I
+		COMMENT Generates renderbuffer object names
 	METHOD method_4831 advancedDeleteRenderBuffers (I)V
+		COMMENT Deletes renderbuffer objects
 		ARG 0 renderbuffer
 	METHOD method_4832 advancedBindFramebuffer (II)V
+		COMMENT Binds a framebuffer to a framebuffer target
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4833 supportsFbo ()Z
+		COMMENT Returns whether OpenGl supports  Frame Buffer Objects
 	METHOD method_4834 advancedDeleteFrameBuffers (I)V
+		COMMENT Deletes framebuffer objects
 		ARG 0 framebuffer
 	METHOD method_4835 advancedBindRenderBuffer (II)V
+		COMMENT Binds a renderbuffer to a renderbuffer target
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4837 advancedCheckFrameBufferStatus (I)I
+		COMMENT Checks the completeness of a framebuffer
 		ARG 0 framebuffer
 	METHOD method_4838 gl13ActiveTexture (I)V
+		COMMENT Allows selecting the active texture unit
 		ARG 0 texture
 	METHOD method_4839 gl13ClientActiveTexture (I)V
+		COMMENT Allows selecting the active texture unit
 		ARG 0 texture

--- a/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlManager
+	FIELD field_5711 ext Z
 	FIELD field_5712 gl21Context Z
 	FIELD field_5714 gl15 Z
 	FIELD field_5718 advancedOpenGlType I
@@ -24,8 +25,8 @@ CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlManager
 	METHOD method_4792 gl20GetProgrami (II)I
 		ARG 0 i
 		ARG 1 j
-	METHOD method_4793 gl30RenderBufferStorage (IIII)V
-	METHOD method_4794 gl30FrameBufferTexture2D (IIIII)V
+	METHOD method_4793 advancedRenderBufferStorage (IIII)V
+	METHOD method_4794 advancedFrameBufferTexture2D (IIIII)V
 	METHOD method_4795 gl20GetUniformLocation (ILjava/lang/CharSequence;)I
 		ARG 0 loc
 		ARG 1 sequence
@@ -51,7 +52,7 @@ CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlManager
 	METHOD method_4803 gl20GetAttachShader (II)V
 		ARG 0 i
 		ARG 1 j
-	METHOD method_4804 gl30FramebufferRenderbuffer (IIII)V
+	METHOD method_4804 advancedFramebufferRenderbuffer (IIII)V
 	METHOD method_4805 gl20GetAttribLocation (ILjava/lang/CharSequence;)I
 		ARG 0 loc
 		ARG 1 sequence
@@ -110,25 +111,25 @@ CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlManager
 	METHOD method_4826 gl20Uniform1 (II)V
 		ARG 0 uniform
 		ARG 1 buf
-	METHOD method_4827 gl30GenFrameBuffers ()I
+	METHOD method_4827 advancedGenFrameBuffers ()I
 	METHOD method_4828 gl15DeleteBuffers (I)V
 		ARG 0 i
 	METHOD method_4829 gl15BindBuffer (II)V
 		ARG 0 i
 		ARG 1 j
-	METHOD method_4830 gl30GenRenderBuffers ()I
-	METHOD method_4831 gl30DeleteRenderBuffers (I)V
+	METHOD method_4830 advancedGenRenderBuffers ()I
+	METHOD method_4831 advancedDeleteRenderBuffers (I)V
 		ARG 0 renderbuffer
-	METHOD method_4832 gl30BindFramebuffer (II)V
+	METHOD method_4832 advancedBindFramebuffer (II)V
 		ARG 0 i
 		ARG 1 j
 	METHOD method_4833 supportsFbo ()Z
-	METHOD method_4834 gl30DeleteFrameBuffers (I)V
+	METHOD method_4834 advancedDeleteFrameBuffers (I)V
 		ARG 0 framebuffer
-	METHOD method_4835 gl30BindRenderBuffer (II)V
+	METHOD method_4835 advancedBindRenderBuffer (II)V
 		ARG 0 i
 		ARG 1 j
-	METHOD method_4837 gl30CheckFrameBufferStatus (I)I
+	METHOD method_4837 advancedCheckFrameBufferStatus (I)I
 		ARG 0 framebuffer
 	METHOD method_4838 gl13ActiveTexture (I)V
 		ARG 0 texture

--- a/mappings/net/minecraft/class_1154.mapping
+++ b/mappings/net/minecraft/class_1154.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_1154
-	FIELD field_4898 features Ljava/util/List;
-	METHOD method_4009 renderFeatures (Lnet/minecraft/class_1752;FFFFFFF)V

--- a/mappings/net/minecraft/client/model/ModelPart.mapping
+++ b/mappings/net/minecraft/client/model/ModelPart.mapping
@@ -2,6 +2,9 @@ CLASS net/minecraft/class_900 net/minecraft/client/model/ModelPart
 	FIELD field_3932 pivotX F
 	FIELD field_3933 pivotY F
 	FIELD field_3934 pivotZ F
+	FIELD field_3935 posX F
+	FIELD field_3936 posY F
+	FIELD field_3937 posZ F
 	FIELD field_3939 visible Z
 	FIELD field_3942 modelList Ljava/util/List;
 	FIELD field_3943 name Ljava/lang/String;

--- a/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/class_1135 net/minecraft/client/render/entity/EntityRenderDispatcher
+	FIELD field_4819 textureManager Lnet/minecraft/class_1232;
+	FIELD field_4829 classMap Ljava/util/Map;
 	FIELD field_4830 modelRenderers Ljava/util/Map;
+	FIELD field_4831 playerRenderer Lnet/minecraft/class_1208;
 	FIELD field_4836 renderHitboxes Z
+	METHOD <init> (Lnet/minecraft/class_1232;Lnet/minecraft/class_1150;)V
+		ARG 1 textureManager
+		ARG 2 itemRenderer
 	METHOD method_3883 shouldRenderHitboxes ()Z
 	METHOD method_3885 setRotation (F)V
 	METHOD method_3886 setWorld (Lnet/minecraft/class_99;)V

--- a/mappings/net/minecraft/client/render/entity/GhastEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/GhastEntityRenderer.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_1143 net/minecraft/client/render/entity/GhastEntityRenderer
+	FIELD field_4848 GHAST Lnet/minecraft/class_1605;
+	FIELD field_4849 GHAST_SHOOTING Lnet/minecraft/class_1605;

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -1,5 +1,9 @@
-CLASS net/minecraft/class_871 net/minecraft/client/render/entity/LivingEntityRenderer
-	FIELD field_3800 parts Ljava/util/List;
-	METHOD method_3052 setAngles (FFFFFFLnet/minecraft/class_1745;)V
-	METHOD method_3058 render (Lnet/minecraft/class_1745;FFFFFF)V
-		ARG 1 entity
+CLASS net/minecraft/class_1154 net/minecraft/client/render/entity/LivingEntityRenderer
+	FIELD field_4894 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_4896 model Lnet/minecraft/class_871;
+	FIELD field_4898 features Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_1135;Lnet/minecraft/class_871;F)V
+		ARG 1 dispatcher
+		ARG 2 model
+		ARG 3 shadowSize
+	METHOD method_4009 renderFeatures (Lnet/minecraft/class_1752;FFFFFFF)V

--- a/mappings/net/minecraft/client/render/entity/PlayerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PlayerEntityRenderer.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/class_1208 net/minecraft/client/render/entity/PlayerEntityRenderer
+	FIELD field_4997 slim Z
+	METHOD <init> (Lnet/minecraft/class_1135;Z)V
+		ARG 1 dispatcher
+		ARG 2 slim
 	METHOD method_4123 setModelPose (Lnet/minecraft/class_993;)V

--- a/mappings/net/minecraft/client/render/entity/SpawnerMinecartEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SpawnerMinecartEntityRenderer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1156 net/minecraft/client/render/entity/SpawnerMinecartEntityRenderer

--- a/mappings/net/minecraft/client/render/entity/model/BannerBlockEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BannerBlockEntityModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_850 net/minecraft/client/render/entity/model/BannerBlockEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/BiPedModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BiPedModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BiPedModel

--- a/mappings/net/minecraft/client/render/entity/model/ChestBlockEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ChestBlockEntityModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_855 net/minecraft/client/render/entity/model/ChestBlockEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/DonkeyEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/DonkeyEntityModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_864 net/minecraft/client/render/entity/model/DonkeyEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/EnderCrystalEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EnderCrystalEntityRenderer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_898 net/minecraft/client/render/entity/model/EnderCrystalEntityRenderer

--- a/mappings/net/minecraft/client/render/entity/model/EntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModel.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_871 net/minecraft/client/render/entity/model/EntityModel
+	FIELD field_3800 parts Ljava/util/List;
+	METHOD method_3052 setAngles (FFFFFFLnet/minecraft/class_1745;)V
+	METHOD method_3053 copy (Lnet/minecraft/class_871;)V
+		ARG 1 model
+	METHOD method_3054 copyModelPart (Lnet/minecraft/class_900;Lnet/minecraft/class_900;)V
+		ARG 0 first
+		ARG 1 second
+	METHOD method_3058 render (Lnet/minecraft/class_1745;FFFFFF)V
+		ARG 1 entity

--- a/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_862 net/minecraft/client/render/entity/model/GhastEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/GhastEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GhastEntityRenderer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_862 net/minecraft/client/render/entity/model/GhastEntityRenderer

--- a/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_876 net/minecraft/client/render/entity/model/QuadruPedEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/SignBlockEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SignBlockEntityModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_880 net/minecraft/client/render/entity/model/SignBlockEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/VillagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/VillagerEntityModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_891 net/minecraft/client/render/entity/model/VillagerEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_893 net/minecraft/client/render/entity/model/WitchEntityModel

--- a/mappings/net/minecraft/client/render/entity/model/WitherEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitherEntityRenderer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_894 net/minecraft/client/render/entity/model/WitherEntityRenderer


### PR DESCRIPTION
I've prefixed the methods in `com.mojang.blaze3d.platform.AdvancedOpenGlManager` with the Gl class that they call. So if method `foo` calls `Glxx.foo`, `foo` would named `glxxFoo`. 
There were too some incorrectly mapped entity models and renderers, which are now fixed.
