### PR TITLE
Achievements' documentation and some classes and enums

### DIFF
--- a/mappings/net/minecraft/achievement/Achievement.mapping
+++ b/mappings/net/minecraft/achievement/Achievement.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_1675 net/minecraft/achievement/Achievement
+	FIELD field_6893 challenge Z
 	METHOD method_6341 setAsChallenge ()Lnet/minecraft/class_1675;
 	METHOD method_6344 isAdvancement ()Z

--- a/mappings/net/minecraft/achievement/Achievements.mapping
+++ b/mappings/net/minecraft/achievement/Achievements.mapping
@@ -1,37 +1,71 @@
 CLASS net/minecraft/class_1676 net/minecraft/achievement/Achievements
 	FIELD field_6894 BLAZE_ROD Lnet/minecraft/class_1675;
+		COMMENT Achieved when a blaze rod is acquired
 	FIELD field_6895 POTION Lnet/minecraft/class_1675;
+		COMMENT Achieved when a potion is brewed
 	FIELD field_6896 THE_END Lnet/minecraft/class_1675;
+		COMMENT Achieved when the player enters the end
 	FIELD field_6897 THE_END_2 Lnet/minecraft/class_1675;
+		COMMENT Achieved when the player kills the enderdragon
 	FIELD field_6898 ENCHANTMENTS Lnet/minecraft/class_1675;
+		COMMENT Achieved when an item is enchanted
 	FIELD field_6899 OVERKILL Lnet/minecraft/class_1675;
+		COMMENT Achieved when 18 points (nine hearts) of damage is dealt by a single strike
 	FIELD field_6900 BOOKCASE Lnet/minecraft/class_1675;
+		COMMENT Achieved when bookshelves are placed around an enchanting table
 	FIELD field_6901 BREED_COW Lnet/minecraft/class_1675;
+		COMMENT Achieved when cows are bred
 	FIELD field_6902 SPAWN_WITHER Lnet/minecraft/class_1675;
+		COMMENT Achieved when a wither is spawned
 	FIELD field_6903 KILL_WITHER Lnet/minecraft/class_1675;
+		COMMENT Achieved when a wither is killed
 	FIELD field_6904 FULL_BEACON Lnet/minecraft/class_1675;
+		COMMENT Achieved when a 9x9 beacon is created
 	FIELD field_6905 EXPORE_ALL_BIOMES Lnet/minecraft/class_1675;
+		COMMENT Achieved when all biomes have been explored
 	FIELD field_6906 OVERPOWERED Lnet/minecraft/class_1675;
+		COMMENT Achieved when all kinds of entities have been killed
 	FIELD field_6911 ACHIEVEMENTS Ljava/util/List;
 	FIELD field_6912 TAKING_INVENTORY Lnet/minecraft/class_1675;
+		COMMENT Achieved when opening the inventory
 	FIELD field_6913 GETTING_WOOD Lnet/minecraft/class_1675;
+		COMMENT Achieved when logs are broken and picked up
 	FIELD field_6914 BUILD_WORK_BENCH Lnet/minecraft/class_1675;
+		COMMENT Achieved when a crafting table is crafted
 	FIELD field_6915 BUILD_PICKAXE Lnet/minecraft/class_1675;
+		COMMENT Achieved when a wooden pickaxe is crafted
 	FIELD field_6916 BUILD_FURNACE Lnet/minecraft/class_1675;
+		COMMENT Achieved when a furnace is crafted
 	FIELD field_6917 ACQUIRE_IRON Lnet/minecraft/class_1675;
+		COMMENT Achieved when an iron ingot is acquired
 	FIELD field_6918 BUILD_HOE Lnet/minecraft/class_1675;
+		COMMENT Achieved when a wooden hoe is crafted
 	FIELD field_6919 MAKE_BREAD Lnet/minecraft/class_1675;
+		COMMENT Achieved when bread is crafted
 	FIELD field_6920 BAKE_CAKE Lnet/minecraft/class_1675;
+		COMMENT Achieved when cake is baked
 	FIELD field_6921 BUILD_BETTER_PICKAXE Lnet/minecraft/class_1675;
+		COMMENT Achieved when a stone pickaxe is crafted
 	FIELD field_6922 COOK_FISH Lnet/minecraft/class_1675;
+		COMMENT Achieved when raw fish or raw salmon is cooked
 	FIELD field_6923 ON_A_RAIL Lnet/minecraft/class_1675;
+		COMMENT Achieved when the player travels in a minecart
 	FIELD field_6924 BUILD_SWORD Lnet/minecraft/class_1675;
+		COMMENT Achieved when a sword is crafted
 	FIELD field_6925 KILL_EMEMY Lnet/minecraft/class_1675;
+		COMMENT Achieved when an entity is killed
 	FIELD field_6926 KILL_COW Lnet/minecraft/class_1675;
+		COMMENT Achieved when a cow is killed for leather
 	FIELD field_6927 FLY_PIG Lnet/minecraft/class_1675;
+		COMMENT Achieved when a player rides a pig off a cliff
 	FIELD field_6928 SNIPE_SKELETON Lnet/minecraft/class_1675;
+		COMMENT Achieved when a skeleton is shot from more than 50 metres away
 	FIELD field_6929 DIAOMNDS Lnet/minecraft/class_1675;
+		COMMENT Achieved when a diamond is acquired
 	FIELD field_6930 DIAMONDS_TO_YOU Lnet/minecraft/class_1675;
+		COMMENT Achieved when diamonds thrown by the player are picked up by another entity
 	FIELD field_6931 PORTAL Lnet/minecraft/class_1675;
+		COMMENT Achieved when a nether portal is made
 	FIELD field_6932 GHAST Lnet/minecraft/class_1675;
+		COMMENT Achieved when a ghast is killed by its own fireball
 	METHOD method_6345 load ()V

--- a/mappings/net/minecraft/entity/EntityType.mapping
+++ b/mappings/net/minecraft/entity/EntityType.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_1746 net/minecraft/entity/EntityType
 	FIELD field_7414 ID_CLASS_MAP Ljava/util/Map;
 	FIELD field_7415 CLASS_ID_MAP Ljava/util/Map;
 	FIELD field_7416 NAME_ID_MAP Ljava/util/Map;
+	METHOD method_7065 load ()V
 	METHOD method_7067 createInstanceFromId (ILnet/minecraft/class_99;)Lnet/minecraft/class_1745;
 	METHOD method_7068 (Lnet/minecraft/class_1405;Lnet/minecraft/class_99;)Lnet/minecraft/class_1745;
 		ARG 0 nbt

--- a/mappings/net/minecraft/stat/CraftingStat.mapping
+++ b/mappings/net/minecraft/stat/CraftingStat.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1679 net/minecraft/stat/CraftingStat

--- a/mappings/net/minecraft/stat/Stats.mapping
+++ b/mappings/net/minecraft/stat/Stats.mapping
@@ -28,6 +28,13 @@ CLASS net/minecraft/class_1687 net/minecraft/stat/Stats
 	FIELD field_6994 ID_TO_STAT Ljava/util/Map;
 	FIELD field_6995 CHEST_OPENED Lnet/minecraft/class_1681;
 	FIELD field_6996 BLOCK_STATS [Lnet/minecraft/class_1681;
+	FIELD field_6997 CRAFTING_STATS [Lnet/minecraft/class_1681;
+	FIELD field_6998 USE_STATS [Lnet/minecraft/class_1681;
+	FIELD field_6999 BREAK_STATS [Lnet/minecraft/class_1681;
+	FIELD field_7000 ALL Ljava/util/List;
+	FIELD field_7001 GENERAL Ljava/util/List;
+	FIELD field_7002 ITEM Ljava/util/List;
+	FIELD field_7003 MINE Ljava/util/List;
 	FIELD field_7004 GAMES_LEFT Lnet/minecraft/class_1681;
 	FIELD field_7005 MINUTES_PLAYED Lnet/minecraft/class_1681;
 	FIELD field_7006 TIME_SINCE_DEATH Lnet/minecraft/class_1681;
@@ -52,3 +59,7 @@ CLASS net/minecraft/class_1687 net/minecraft/stat/Stats
 	METHOD method_6385 setup ()V
 	METHOD method_6389 ([Lnet/minecraft/class_1681;)V
 		ARG 0 stats
+	METHOD method_6391 loadCraftingStats ()V
+	METHOD method_6393 loadBlockStats ()V
+	METHOD method_6394 loadUseStats ()V
+	METHOD method_6395 loadBreakStats ()V

--- a/mappings/net/minecraft/state/StateManager.mapping
+++ b/mappings/net/minecraft/state/StateManager.mapping
@@ -10,3 +10,12 @@ CLASS net/minecraft/class_378 net/minecraft/state/StateManager
 	METHOD method_1229 getDefaultState ()Lnet/minecraft/class_376;
 	METHOD method_1230 getBlock ()Lnet/minecraft/class_160;
 	METHOD method_1231 getProperties ()Ljava/util/Collection;
+	CLASS class_379 BlockStateImpl
+		FIELD field_1507 block Lnet/minecraft/class_160;
+		FIELD field_1508 map Lcom/google/common/collect/ImmutableMap;
+		FIELD field_1509 table Lcom/google/common/collect/ImmutableTable;
+		METHOD <init> (Lnet/minecraft/class_160;Lcom/google/common/collect/ImmutableMap;)V
+			ARG 1 block
+			ARG 2 map
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 1 object

--- a/mappings/net/minecraft/text/BaseText.mapping
+++ b/mappings/net/minecraft/text/BaseText.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1441 net/minecraft/text/BaseText
 	FIELD field_5995 siblings Ljava/util/List;
+	FIELD field_5996 style Lnet/minecraft/class_1451;
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 object

--- a/mappings/net/minecraft/text/ClickEvent.mapping
+++ b/mappings/net/minecraft/text/ClickEvent.mapping
@@ -1,11 +1,28 @@
 CLASS net/minecraft/class_1442 net/minecraft/text/ClickEvent
+	FIELD field_5997 action Lnet/minecraft/class_1442$class_1443;
 	FIELD field_5998 value Ljava/lang/String;
+	METHOD <init> (Lnet/minecraft/class_1442$class_1443;Ljava/lang/String;)V
+		ARG 1 action
+		ARG 2 value
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 object
 	METHOD method_5153 getAction ()Lnet/minecraft/class_1442$class_1443;
 	METHOD method_5154 getValue ()Ljava/lang/String;
 	CLASS class_1443 Action
+		FIELD field_5999 OPEN_URL Lnet/minecraft/class_1442$class_1443;
+		FIELD field_6000 OPEN_FILE Lnet/minecraft/class_1442$class_1443;
+		FIELD field_6001 RUN_COMMAND Lnet/minecraft/class_1442$class_1443;
+		FIELD field_6002 TWITCH_USER_INFO Lnet/minecraft/class_1442$class_1443;
+		FIELD field_6003 SUGGEST_COMMAND Lnet/minecraft/class_1442$class_1443;
+		FIELD field_6004 CHANGE_PAGE Lnet/minecraft/class_1442$class_1443;
+		FIELD field_6005 ACTIONS Ljava/util/Map;
 		FIELD field_6006 userDefinable Z
 		FIELD field_6007 name Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Z)V
+			ARG 3 name
+			ARG 4 userDefinable
 		METHOD method_5155 isUserDefinable ()Z
 		METHOD method_5156 byName (Ljava/lang/String;)Lnet/minecraft/class_1442$class_1443;
 			ARG 0 name
 		METHOD method_5157 getName ()Ljava/lang/String;
+		METHOD values ()[Lnet/minecraft/class_1442$class_1443;

--- a/mappings/net/minecraft/text/HoverEvent.mapping
+++ b/mappings/net/minecraft/text/HoverEvent.mapping
@@ -1,10 +1,26 @@
 CLASS net/minecraft/class_1447 net/minecraft/text/HoverEvent
+	FIELD field_6010 action Lnet/minecraft/class_1447$class_1448;
+	FIELD field_6011 value Lnet/minecraft/class_1444;
+	METHOD <init> (Lnet/minecraft/class_1447$class_1448;Lnet/minecraft/class_1444;)V
+		ARG 1 action
+		ARG 2 text
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 object
 	METHOD method_5173 getAction ()Lnet/minecraft/class_1447$class_1448;
 	METHOD method_5174 getValue ()Lnet/minecraft/class_1444;
 	CLASS class_1448 Action
+		FIELD field_6012 SHOW_TEXT Lnet/minecraft/class_1447$class_1448;
+		FIELD field_6013 SHOW_ACHIEVEMENT Lnet/minecraft/class_1447$class_1448;
+		FIELD field_6014 SHOW_ITEM Lnet/minecraft/class_1447$class_1448;
+		FIELD field_6015 SHOW_ENTITY Lnet/minecraft/class_1447$class_1448;
+		FIELD field_6016 ACTIONS Ljava/util/Map;
 		FIELD field_6017 userDefinable Z
 		FIELD field_6018 name Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Z)V
+			ARG 3 name
+			ARG 4 userDefinable
 		METHOD method_5175 isUserDefinable ()Z
 		METHOD method_5176 byName (Ljava/lang/String;)Lnet/minecraft/class_1447$class_1448;
 			ARG 0 name
 		METHOD method_5177 getName ()Ljava/lang/String;
+		METHOD values ()[Lnet/minecraft/class_1447$class_1448;

--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1444 net/minecraft/text/Text
+	METHOD method_5158 getSiblings ()Ljava/util/List;
 	METHOD method_5159 append (Lnet/minecraft/class_1444;)Lnet/minecraft/class_1444;
 		ARG 1 text
 	METHOD method_5160 setStyle (Lnet/minecraft/class_1451;)Lnet/minecraft/class_1444;


### PR DESCRIPTION
Enums are so easy to map.

Changelog:-
```sql
 On branch dev4
 Changes to be committed:
	modified:   mappings/net/minecraft/achievement/Achievement.mapping
	modified:   mappings/net/minecraft/achievement/Achievements.mapping
	modified:   mappings/net/minecraft/entity/EntityType.mapping
	new file:   mappings/net/minecraft/stat/CraftingStat.mapping
	modified:   mappings/net/minecraft/stat/Stats.mapping
	modified:   mappings/net/minecraft/state/StateManager.mapping
	modified:   mappings/net/minecraft/text/BaseText.mapping
	modified:   mappings/net/minecraft/text/ClickEvent.mapping
	modified:   mappings/net/minecraft/text/HoverEvent.mapping
	modified:   mappings/net/minecraft/text/Text.mapping
```