### PR TITLE
Gl refactors

### DIFF
--- a/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
@@ -1,20 +1,42 @@
 CLASS net/minecraft/class_1355 com/mojang/blaze3d/platform/AdvancedOpenGlManager
-	FIELD field_5711 ext Z
-	FIELD field_5712 gl21Context Z
-	FIELD field_5714 gl15 Z
-	FIELD field_5718 advancedOpenGlType I
-	FIELD field_5719 gl21 Z
+	FIELD field_5711 blendFuncSeperateSupported Z
+	FIELD field_5712 gl21Supported Z
+	FIELD field_5713 shadersSupported Z
+	FIELD field_5714 vboSupported Z
+	FIELD field_5716 arrayBuffer I
+	FIELD field_5718 type I
+	FIELD field_5719 shaders Z
 	FIELD field_5720 arbShaderObjects Z
 	FIELD field_5721 arbMultitexture Z
 	FIELD field_5722 arbTextureEnvCombine Z
-	FIELD field_5723 gl14Context Z
+	FIELD field_5723 gl14Supported Z
 	FIELD field_5724 contextDescription Ljava/lang/String;
 	FIELD field_5725 nvidia Z
-	FIELD field_5727 gl15Context Z
+	FIELD field_5726 processor Ljava/lang/String;
+	FIELD field_5727 vboShadersSupported Z
 	FIELD field_5728 amd Z
 	FIELD field_5729 framebuffer I
 	FIELD field_5730 renderbuffer I
+	FIELD field_5731 colorAttachment I
+	FIELD field_5732 depthAttachment I
+	FIELD field_5733 completeFramebuffer I
+	FIELD field_5734 incompleteFramebufferAttachment I
+	FIELD field_5735 incompleteFramebufferAttachmentMiss I
+	FIELD field_5736 incompleteFramebufferAttachmentDraw I
+	FIELD field_5737 incompleteFramebufferAttachmentRead I
 	FIELD field_5738 advanced Z
+	FIELD field_5739 linkStatus I
+	FIELD field_5740 compileStatus I
+	FIELD field_5741 vertexShader I
+	FIELD field_5742 fragmentShader I
+	FIELD field_5743 textureUnit I
+	FIELD field_5744 lightmapTextureUnit I
+	FIELD field_5745 texture I
+	FIELD field_5746 combine I
+	FIELD field_5747 interpolate I
+	FIELD field_5748 primary I
+	FIELD field_5749 constant I
+	FIELD field_5750 previous I
 	METHOD method_4789 createContext ()V
 	METHOD method_4790 gl20DeleteShader (I)V
 		COMMENT Deletes a shader object

--- a/mappings/net/minecraft/GrassColorResourceReloadListener.mapping
+++ b/mappings/net/minecraft/GrassColorResourceReloadListener.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_1255 net/minecraft/GrassColorResourceReloadListener
+	FIELD field_5237 GRASS_COLOR_TEXTURE Lnet/minecraft/class_1605;

--- a/mappings/net/minecraft/class_1984.mapping
+++ b/mappings/net/minecraft/class_1984.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1984

--- a/mappings/net/minecraft/client/entity/VillageParticle.mapping
+++ b/mappings/net/minecraft/client/entity/VillageParticle.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_981 net/minecraft/client/entity/VillageParticle
-	CLASS class_982 HappyVillagerFactory
-	CLASS class_983 TownAuraFactory

--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_679 net/minecraft/client/font/TextRenderer
 	FIELD field_2815 fontHeight I
 	FIELD field_2816 random Ljava/util/Random;
-	FIELD field_2817 pages [Lnet/minecraft/class_1605;
+	FIELD field_2817 PAGES [Lnet/minecraft/class_1605;
 	FIELD field_2821 fontTexture Lnet/minecraft/class_1605;
 	FIELD field_2822 textureManager Lnet/minecraft/class_1232;
 	FIELD field_2826 rightToLeft Z

--- a/mappings/net/minecraft/client/gl/Framebuffer.mapping
+++ b/mappings/net/minecraft/client/gl/Framebuffer.mapping
@@ -20,14 +20,24 @@ CLASS net/minecraft/class_1040 net/minecraft/client/gl/Framebuffer
 		ARG 3 b
 		ARG 4 a
 	METHOD method_3556 setTexFilter (I)V
+		ARG 1 texFilter
 	METHOD method_3557 resize (II)V
+		ARG 1 width
+		ARG 2 height
 	METHOD method_3558 drawInternal (IIZ)V
 		ARG 1 width
 		ARG 2 height
+		ARG 3 colorMaterial
+	METHOD method_3559 bind (Z)V
+		ARG 1 viewPort
 	METHOD method_3560 checkFramebufferStatus ()V
+	METHOD method_3561 attachTexture (II)V
+		ARG 1 width
+		ARG 2 height
 	METHOD method_3562 beginRead ()V
 	METHOD method_3563 draw (II)V
 		ARG 1 width
 		ARG 2 height
 	METHOD method_3564 endRead ()V
 	METHOD method_3565 endWrite ()V
+	METHOD method_3566 clear ()V

--- a/mappings/net/minecraft/client/gl/GlBlendState.mapping
+++ b/mappings/net/minecraft/client/gl/GlBlendState.mapping
@@ -7,6 +7,16 @@ CLASS net/minecraft/class_1209 net/minecraft/client/gl/GlBlendState
 	FIELD field_5003 func I
 	FIELD field_5004 separateBlend Z
 	FIELD field_5005 blendDisabled Z
+	METHOD <init> (III)V
+		ARG 1 srcRgb
+		ARG 2 dstRgb
+		ARG 3 func
+	METHOD <init> (IIIII)V
+		ARG 1 srcRgb
+		ARG 2 dstRgb
+		ARG 3 srcAlpha
+		ARG 4 dstAlpha
+		ARG 5 func
 	METHOD <init> (ZZIIIII)V
 		ARG 1 separateBlend
 		ARG 2 blendDisabled

--- a/mappings/net/minecraft/client/gl/GlProgramManager.mapping
+++ b/mappings/net/minecraft/client/gl/GlProgramManager.mapping
@@ -1,3 +1,10 @@
 CLASS net/minecraft/class_1216 net/minecraft/client/gl/GlProgramManager
 	FIELD field_5056 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_5057 instance Lnet/minecraft/class_1216;
+	METHOD method_4171 newInstance ()V
+	METHOD method_4172 destroyProgram (Lnet/minecraft/class_1211;)V
+		ARG 1 program
+	METHOD method_4173 getInstance ()Lnet/minecraft/class_1216;
+	METHOD method_4174 attachProgram (Lnet/minecraft/class_1211;)V
+		ARG 1 program
 	METHOD method_4175 createProgram ()I

--- a/mappings/net/minecraft/client/gl/GlUniform.mapping
+++ b/mappings/net/minecraft/client/gl/GlUniform.mapping
@@ -7,6 +7,12 @@ CLASS net/minecraft/class_1217 net/minecraft/client/gl/GlUniform
 	FIELD field_5063 floatData Ljava/nio/FloatBuffer;
 	FIELD field_5064 name Ljava/lang/String;
 	FIELD field_5065 stateDirty Z
+	FIELD field_5066 program Lnet/minecraft/class_1211;
+	METHOD <init> (Ljava/lang/String;IILnet/minecraft/class_1211;)V
+		ARG 1 name
+		ARG 2 datatype
+		ARG 3 count
+		ARG 4 program
 	METHOD method_4176 getName ()Ljava/lang/String;
 	METHOD method_4183 getTypeIndex (Ljava/lang/String;)I
 		ARG 0 typeName

--- a/mappings/net/minecraft/client/gl/JsonGlProgram.mapping
+++ b/mappings/net/minecraft/client/gl/JsonGlProgram.mapping
@@ -1,6 +1,9 @@
 CLASS net/minecraft/class_1211 net/minecraft/client/gl/JsonGlProgram
 	FIELD field_5006 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_5007 UNIFORM Lnet/minecraft/class_1210;
+	FIELD field_5008 activeProgram Lnet/minecraft/class_1211;
 	FIELD field_5009 activeProgramRef I
+	FIELD field_5010 active Z
 	FIELD field_5011 samplerBinds Ljava/util/Map;
 	FIELD field_5012 samplerNames Ljava/util/List;
 	FIELD field_5013 samplerShaderLocs Ljava/util/List;
@@ -13,6 +16,11 @@ CLASS net/minecraft/class_1211 net/minecraft/client/gl/JsonGlProgram
 	FIELD field_5020 uniformStateDirty Z
 	FIELD field_5022 attribLocs Ljava/util/List;
 	FIELD field_5023 attribNames Ljava/util/List;
+	FIELD field_5024 vertex Lnet/minecraft/class_1214;
+	FIELD field_5025 fragment Lnet/minecraft/class_1214;
+	METHOD <init> (Lnet/minecraft/class_1258;Ljava/lang/String;)V
+		ARG 1 manager
+		ARG 2 name
 	METHOD method_4131 addSampler (Lcom/google/gson/JsonElement;)V
 	METHOD method_4132 getUniformByName (Ljava/lang/String;)Lnet/minecraft/class_1217;
 		ARG 1 name
@@ -21,4 +29,7 @@ CLASS net/minecraft/class_1211 net/minecraft/client/gl/JsonGlProgram
 	METHOD method_4134 disable ()V
 	METHOD method_4135 addUniform (Lcom/google/gson/JsonElement;)V
 	METHOD method_4137 enable ()V
+	METHOD method_4139 getVsh ()Lnet/minecraft/class_1214;
+	METHOD method_4140 getFsh ()Lnet/minecraft/class_1214;
+	METHOD method_4141 getProgramRef ()I
 	METHOD method_4142 finalizeUniformsAndSamplers ()V

--- a/mappings/net/minecraft/client/particle/VillageParticle.mapping
+++ b/mappings/net/minecraft/client/particle/VillageParticle.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_981 net/minecraft/client/particle/VillageParticle
+	CLASS class_982 HappyVillagerFactory
+	CLASS class_983 TownAuraFactory

--- a/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderDispatcher.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderDispatcher.mapping
@@ -2,12 +2,23 @@ CLASS net/minecraft/class_1093 net/minecraft/client/render/block/entity/BlockEnt
 	FIELD field_4667 INSTANCE Lnet/minecraft/class_1093;
 	FIELD field_4671 textureManager Lnet/minecraft/class_1232;
 	FIELD field_4672 world Lnet/minecraft/class_99;
+	FIELD field_4673 entity Lnet/minecraft/class_1745;
 	FIELD field_4679 renderers Ljava/util/Map;
 	FIELD field_4680 textRenderer Lnet/minecraft/class_679;
 	METHOD method_3741 getTextRenderer ()Lnet/minecraft/class_679;
 	METHOD method_3742 setWorld (Lnet/minecraft/class_99;)V
 		ARG 1 world
+	METHOD method_3743 (Lnet/minecraft/class_99;Lnet/minecraft/class_1232;Lnet/minecraft/class_679;Lnet/minecraft/class_1745;F)V
+		ARG 1 world
+		ARG 2 textureManager
+		ARG 3 textRenderer
+		ARG 4 entity
 	METHOD method_3744 renderEntity (Lnet/minecraft/class_348;DDDF)V
+		ARG 1 blockEntity
 	METHOD method_3745 renderEntity (Lnet/minecraft/class_348;DDDFI)V
 		ARG 1 entity
 	METHOD method_3746 renderEntity (Lnet/minecraft/class_348;FI)V
+	METHOD method_3747 (Ljava/lang/Class;)Lnet/minecraft/class_1094;
+		ARG 1 clazz
+	METHOD method_3748 (Lnet/minecraft/class_348;)Lnet/minecraft/class_1094;
+		ARG 1 blockEntity

--- a/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderer.mapping
@@ -1,2 +1,14 @@
 CLASS net/minecraft/class_1094 net/minecraft/client/render/block/entity/BlockEntityRenderer
+	FIELD field_4681 DESTROY_STAGE_TEXTURE [Lnet/minecraft/class_1605;
+	FIELD field_4682 dispatcher Lnet/minecraft/class_1093;
 	METHOD method_3750 render (Lnet/minecraft/class_348;DDDFI)V
+		ARG 1 blockEntity
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+	METHOD method_3751 setDispatcher (Lnet/minecraft/class_1093;)V
+		ARG 1 dispatcher
+	METHOD method_3752 bindTexture (Lnet/minecraft/class_1605;)V
+		ARG 1 texture
+	METHOD method_3753 getWorld ()Lnet/minecraft/class_99;
+	METHOD method_3754 getTextRenderer ()Lnet/minecraft/class_679;

--- a/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/class_1135 net/minecraft/client/render/entity/EntityRenderDispatcher
 	FIELD field_4819 textureManager Lnet/minecraft/class_1232;
-	FIELD field_4829 classMap Ljava/util/Map;
+	FIELD field_4820 world Lnet/minecraft/class_99;
+	FIELD field_4829 renderers Ljava/util/Map;
 	FIELD field_4830 modelRenderers Ljava/util/Map;
 	FIELD field_4831 playerRenderer Lnet/minecraft/class_1208;
+	FIELD field_4832 textRenderer Lnet/minecraft/class_679;
 	FIELD field_4836 renderHitboxes Z
 	METHOD <init> (Lnet/minecraft/class_1232;Lnet/minecraft/class_1150;)V
 		ARG 1 textureManager
@@ -10,6 +12,7 @@ CLASS net/minecraft/class_1135 net/minecraft/client/render/entity/EntityRenderDi
 	METHOD method_3883 shouldRenderHitboxes ()Z
 	METHOD method_3885 setRotation (F)V
 	METHOD method_3886 setWorld (Lnet/minecraft/class_99;)V
+		ARG 1 world
 	METHOD method_3890 render (Lnet/minecraft/class_1745;DDDFF)Z
 	METHOD method_3895 setRenderShadows (Z)V
 		ARG 1 value

--- a/mappings/net/minecraft/command/Command.mapping
+++ b/mappings/net/minecraft/command/Command.mapping
@@ -1,8 +1,17 @@
 CLASS net/minecraft/class_1606 net/minecraft/command/Command
 	METHOD method_5884 isAccessible (Lnet/minecraft/class_1659;)Z
+		ARG 1 source
 	METHOD method_5885 execute (Lnet/minecraft/class_1659;[Ljava/lang/String;)V
 		ARG 1 source
 		ARG 2 args
-	METHOD method_5889 getName ()Ljava/lang/String;
+	METHOD method_5886 getAutoCompleteHints (Lnet/minecraft/class_1659;[Ljava/lang/String;Lnet/minecraft/class_1372;)Ljava/util/List;
+		ARG 1 source
+		ARG 2 args
+		ARG 3 pos
+	METHOD method_5887 getAliases ()Ljava/util/List;
+	METHOD method_5888 isUsernameAtIndex ([Ljava/lang/String;I)Z
+		ARG 1 args
+		ARG 2 index
+	METHOD method_5889 getCommandName ()Ljava/lang/String;
 	METHOD method_5890 getUsageTranslationKey (Lnet/minecraft/class_1659;)Ljava/lang/String;
 		ARG 1 source

--- a/mappings/net/minecraft/command/CommandException.mapping
+++ b/mappings/net/minecraft/command/CommandException.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_1363 net/minecraft/command/CommandException
+	FIELD field_5754 args [Ljava/lang/Object;
+	METHOD <init> (Ljava/lang/String;[Ljava/lang/Object;)V
+		ARG 1 reason
+		ARG 2 args
+	METHOD method_4844 getArgs ()[Ljava/lang/Object;

--- a/mappings/net/minecraft/command/CommandSource.mapping
+++ b/mappings/net/minecraft/command/CommandSource.mapping
@@ -1,11 +1,16 @@
 CLASS net/minecraft/class_1659 net/minecraft/command/CommandSource
 	METHOD method_133 getNameText ()Lnet/minecraft/class_1444;
+	METHOD method_6255 canUseCommand (ILjava/lang/String;)Z
+		ARG 1 permissionLevel
+		ARG 2 commandLiteral
 	METHOD method_6256 sendMessage (Lnet/minecraft/class_1444;)V
-	METHOD method_6257 feedback (Lnet/minecraft/class_1685$class_1686;I)V
+		ARG 1 text
+	METHOD method_6257 setStat (Lnet/minecraft/class_1685$class_1686;I)V
 		ARG 1 statsType
 		ARG 2 value
 	METHOD method_6258 getBlockPos ()Lnet/minecraft/class_1372;
 	METHOD method_6259 getPos ()Lnet/minecraft/class_649;
 	METHOD method_6260 getWorld ()Lnet/minecraft/class_99;
+	METHOD method_6261 getNameString ()Ljava/lang/String;
 	METHOD method_6262 getEntity ()Lnet/minecraft/class_1745;
 	METHOD method_6263 sendCommandFeedback ()Z

--- a/mappings/net/minecraft/effect/entity/HealthBoostStatusEffect.mapping
+++ b/mappings/net/minecraft/effect/entity/HealthBoostStatusEffect.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_1739 net/minecraft/effect/entity/HealthBoostStatusEffect

--- a/mappings/net/minecraft/entity/effect/HealthBoostStatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/HealthBoostStatusEffect.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/class_1984 net/minecraft/entity/effect/HealthBoostStatusEffect
+CLASS net/minecraft/class_1739 net/minecraft/entity/effect/HealthBoostStatusEffect

--- a/mappings/net/minecraft/entity/effect/StatusEffectStrings.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffectStrings.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_34 net/minecraft/effect/StatusEffectStrings
+CLASS net/minecraft/class_34 net/minecraft/entity/effect/StatusEffectStrings
 	FIELD field_68 UNCRAFTABLE Ljava/lang/String;
 	FIELD field_69 SUGAR Ljava/lang/String;
 	FIELD field_70 GHAST_TEAR Ljava/lang/String;

--- a/mappings/net/minecraft/resource/FoliageColorResourceReloadListener.mapping
+++ b/mappings/net/minecraft/resource/FoliageColorResourceReloadListener.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_1254 net/minecraft/resource/FoliageColorResourceReloadListener
+	FIELD field_5236 FOLIAGE_TEXTURE Lnet/minecraft/class_1605;

--- a/mappings/net/minecraft/server/command/Console.mapping
+++ b/mappings/net/minecraft/server/command/Console.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_1669 net/minecraft/server/command/Console
 	FIELD field_6844 INSTANCE Lnet/minecraft/class_1669;
+	FIELD field_6845 text Ljava/lang/StringBuffer;
 	METHOD method_6303 getInstance ()Lnet/minecraft/class_1669;
+	METHOD method_6304 destroy ()V
+	METHOD method_6305 getTextAsString ()Ljava/lang/String;


### PR DESCRIPTION
Fixes incorrect mappings and maps client stuff

Closes #59 

```python
﻿ On branch dev12
 Changes to be committed:
	modified:   mappings/com/mojang/blaze3d/platform/AdvancedOpenGlManager.mapping
	new file:   mappings/net/minecraft/GrassColorResourceReloadListener.mapping
	new file:   mappings/net/minecraft/class_1984.mapping
	deleted:    mappings/net/minecraft/client/entity/VillageParticle.mapping
	modified:   mappings/net/minecraft/client/font/TextRenderer.mapping
	modified:   mappings/net/minecraft/client/gl/Framebuffer.mapping
	modified:   mappings/net/minecraft/client/gl/GlBlendState.mapping
	modified:   mappings/net/minecraft/client/gl/GlProgramManager.mapping
	modified:   mappings/net/minecraft/client/gl/GlUniform.mapping
	modified:   mappings/net/minecraft/client/gl/JsonGlProgram.mapping
	new file:   mappings/net/minecraft/client/particle/VillageParticle.mapping
	modified:   mappings/net/minecraft/client/render/block/entity/BlockEntityRenderDispatcher.mapping
	modified:   mappings/net/minecraft/client/render/block/entity/BlockEntityRenderer.mapping
	modified:   mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
	modified:   mappings/net/minecraft/command/Command.mapping
	modified:   mappings/net/minecraft/command/CommandException.mapping
	modified:   mappings/net/minecraft/command/CommandSource.mapping
	deleted:    mappings/net/minecraft/effect/entity/HealthBoostStatusEffect.mapping
	modified:   mappings/net/minecraft/entity/effect/HealthBoostStatusEffect.mapping
	renamed:    mappings/net/minecraft/effect/StatusEffectStrings.mapping -> mappings/net/minecraft/entity/effect/StatusEffectStrings.mapping
	new file:   mappings/net/minecraft/resource/FoliageColorResourceReloadListener.mapping
	modified:   mappings/net/minecraft/server/command/Console.mapping
```
