### PR TITLE
Material

### DIFF
--- a/mappings/net/minecraft/block/FluidMaterial.mapping
+++ b/mappings/net/minecraft/block/FluidMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1242 net/minecraft/block/FluidMaterial

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -1,26 +1,64 @@
 CLASS net/minecraft/class_1241 net/minecraft/block/Material
-	FIELD field_26185 CLAY Lnet/minecraft/class_1241;
+	FIELD field_26184 CACTUS Lnet/minecraft/class_1241;
+	FIELD field_26185 ORGANIC_PRODUCT Lnet/minecraft/class_1241;
+	FIELD field_26186 GOURD Lnet/minecraft/class_1241;
+	FIELD field_26187 EGG Lnet/minecraft/class_1241;
+	FIELD field_26188 PORTAL Lnet/minecraft/class_1241;
+	FIELD field_26189 CAKE Lnet/minecraft/class_1241;
+	FIELD field_26190 COBWEB Lnet/minecraft/class_1241;
+	FIELD field_26191 PISTON Lnet/minecraft/class_1241;
+	FIELD field_26192 BARRIER Lnet/minecraft/class_1241;
+	FIELD field_26193 STRUCTURE_VOID Lnet/minecraft/class_1241;
+	FIELD field_26194 burnable Z
+	FIELD field_26195 replaceable Z
+	FIELD field_26196 allowsLight Z
 	FIELD field_26197 color Lnet/minecraft/class_1243;
-	FIELD field_26199 PISTON Lnet/minecraft/class_3686;
+	FIELD field_26198 breakByHand Z
+	FIELD field_26199 pistonBehavior Lnet/minecraft/class_3686;
+	FIELD field_26200 breakingRestricted Z
 	FIELD field_26201 AIR Lnet/minecraft/class_1241;
-	FIELD field_26202 GRASS Lnet/minecraft/class_1241;
-	FIELD field_26203 DIRT Lnet/minecraft/class_1241;
+	FIELD field_26202 SOLID_ORGANIC Lnet/minecraft/class_1241;
+	FIELD field_26203 SOIL Lnet/minecraft/class_1241;
 	FIELD field_26204 WOOD Lnet/minecraft/class_1241;
 	FIELD field_26205 STONE Lnet/minecraft/class_1241;
-	FIELD field_26206 IRON Lnet/minecraft/class_1241;
-	FIELD field_26207 METAL Lnet/minecraft/class_1241;
+	FIELD field_26206 METAL Lnet/minecraft/class_1241;
+	FIELD field_26207 REPAIR_STATION Lnet/minecraft/class_1241;
 	FIELD field_26208 WATER Lnet/minecraft/class_1241;
 	FIELD field_26209 LAVA Lnet/minecraft/class_1241;
-	FIELD field_26210 FOILAGE Lnet/minecraft/class_1241;
-	FIELD field_26213 YELLOW Lnet/minecraft/class_1241;
-	FIELD field_26214 WEB Lnet/minecraft/class_1241;
+	FIELD field_26210 LEAVES Lnet/minecraft/class_1241;
+	FIELD field_26211 PLANT Lnet/minecraft/class_1241;
+	FIELD field_26212 REPLACEABLE_PLANT Lnet/minecraft/class_1241;
+	FIELD field_26213 SPONGE Lnet/minecraft/class_1241;
+	FIELD field_26214 WOOL Lnet/minecraft/class_1241;
+	FIELD field_26215 FIRE Lnet/minecraft/class_1241;
 	FIELD field_26216 AGGREGATE Lnet/minecraft/class_1241;
 		COMMENT A material or structure formed from a loosely compacted mass of fragments or particles.
-	FIELD field_26224 ICE Lnet/minecraft/class_1241;
-	FIELD field_26225 WHITE Lnet/minecraft/class_1241;
+	FIELD field_26217 SUPPORTED Lnet/minecraft/class_1241;
+	FIELD field_26218 CARPET Lnet/minecraft/class_1241;
+	FIELD field_26219 GLASS Lnet/minecraft/class_1241;
+	FIELD field_26220 REDSTONE_LAMP Lnet/minecraft/class_1241;
+	FIELD field_26221 TNT Lnet/minecraft/class_1241;
+	FIELD field_26222 UNUSED_PLANT Lnet/minecraft/class_1241;
+	FIELD field_26223 ICE Lnet/minecraft/class_1241;
+	FIELD field_26224 DENSE_ICE Lnet/minecraft/class_1241;
+	FIELD field_26225 SNOW_LAYER Lnet/minecraft/class_1241;
+	FIELD field_26226 SNOW_BLOCK Lnet/minecraft/class_1241;
 	METHOD <init> (Lnet/minecraft/class_1243;)V
 		ARG 1 color
 	METHOD method_28060 isSolid ()Z
+	METHOD method_28061 allowsLight ()Z
+	METHOD method_28062 blocksMovement ()Z
 	METHOD method_28063 isLiquid ()Z
+	METHOD method_28064 toolRequired ()Lnet/minecraft/class_1241;
+	METHOD method_28065 burnable ()Lnet/minecraft/class_1241;
+	METHOD method_28066 isBurnable ()Z
+	METHOD method_28067 replaceable ()Lnet/minecraft/class_1241;
+	METHOD method_28068 isReplaceable ()Z
+	METHOD method_28069 isOpaque ()Z
+	METHOD method_28070 canBreakByHand ()Z
 	METHOD method_28071 getPistonBehavior ()Lnet/minecraft/class_3686;
+	METHOD method_28072 destroyedByPiston ()Lnet/minecraft/class_1241;
+	METHOD method_28073 blocksPistons ()Lnet/minecraft/class_1241;
+	METHOD method_28074 breakingRestricted ()Lnet/minecraft/class_1241;
 	METHOD method_28075 getColor ()Lnet/minecraft/class_1243;
+	METHOD method_28076 lightPassesThrough ()Lnet/minecraft/class_1241;

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_1241 net/minecraft/block/Material
 	FIELD field_26197 color Lnet/minecraft/class_1243;
 	FIELD field_26198 breakByHand Z
 	FIELD field_26199 pistonBehavior Lnet/minecraft/class_3686;
-	FIELD field_26200 breakingRestricted Z
+	FIELD field_26200 ignoreAdventureMode Z
 	FIELD field_26201 AIR Lnet/minecraft/class_1241;
 	FIELD field_26202 SOLID_ORGANIC Lnet/minecraft/class_1241;
 	FIELD field_26203 SOIL Lnet/minecraft/class_1241;
@@ -59,6 +59,6 @@ CLASS net/minecraft/class_1241 net/minecraft/block/Material
 	METHOD method_28071 getPistonBehavior ()Lnet/minecraft/class_3686;
 	METHOD method_28072 destroyedByPiston ()Lnet/minecraft/class_1241;
 	METHOD method_28073 blocksPistons ()Lnet/minecraft/class_1241;
-	METHOD method_28074 breakingRestricted ()Lnet/minecraft/class_1241;
+	METHOD method_28074 ignoreAdventureMode ()Lnet/minecraft/class_1241;
 	METHOD method_28075 getColor ()Lnet/minecraft/class_1243;
 	METHOD method_28076 lightPassesThrough ()Lnet/minecraft/class_1241;

--- a/mappings/net/minecraft/block/MaterialColor.mapping
+++ b/mappings/net/minecraft/block/MaterialColor.mapping
@@ -1,8 +1,14 @@
 CLASS net/minecraft/class_1243 net/minecraft/block/MaterialColor
+	FIELD field_26232 PURPLE Lnet/minecraft/class_1243;
+	FIELD field_26233 BLUE Lnet/minecraft/class_1243;
 	FIELD field_26234 BROWN Lnet/minecraft/class_1243;
+	FIELD field_26235 GREEN Lnet/minecraft/class_1243;
 	FIELD field_26236 RED Lnet/minecraft/class_1243;
 	FIELD field_26237 BLACK Lnet/minecraft/class_1243;
+	FIELD field_26238 GOLD Lnet/minecraft/class_1243;
 	FIELD field_26239 DIAMOND Lnet/minecraft/class_1243;
+	FIELD field_26240 LAPIS Lnet/minecraft/class_1243;
+	FIELD field_26241 EMERALD Lnet/minecraft/class_1243;
 	FIELD field_26242 SPRUCE Lnet/minecraft/class_1243;
 	FIELD field_26243 NETHER Lnet/minecraft/class_1243;
 	FIELD field_26244 WHITE_TERRACOTTA Lnet/minecraft/class_1243;
@@ -24,7 +30,8 @@ CLASS net/minecraft/class_1243 net/minecraft/block/MaterialColor
 	FIELD field_26260 BLACK_TERRACOTTA Lnet/minecraft/class_1243;
 	FIELD field_26261 color I
 	FIELD field_26262 id I
-	FIELD field_26264 AIR Lnet/minecraft/class_1243;
+	FIELD field_26263 BLOCK_COLORS [Lnet/minecraft/class_1243;
+	FIELD field_26264 CLEAR Lnet/minecraft/class_1243;
 	FIELD field_26265 GRASS Lnet/minecraft/class_1243;
 	FIELD field_26266 SAND Lnet/minecraft/class_1243;
 	FIELD field_26267 WEB Lnet/minecraft/class_1243;
@@ -40,9 +47,18 @@ CLASS net/minecraft/class_1243 net/minecraft/block/MaterialColor
 	FIELD field_26277 WOOD Lnet/minecraft/class_1243;
 	FIELD field_26278 QUARTZ Lnet/minecraft/class_1243;
 	FIELD field_26279 ORANGE Lnet/minecraft/class_1243;
+	FIELD field_26280 MAGENTA Lnet/minecraft/class_1243;
+	FIELD field_26281 LIGHT_BLUE Lnet/minecraft/class_1243;
 	FIELD field_26282 YELLOW Lnet/minecraft/class_1243;
+	FIELD field_26283 LIME Lnet/minecraft/class_1243;
+	FIELD field_26284 PINK Lnet/minecraft/class_1243;
+	FIELD field_26285 GRAY Lnet/minecraft/class_1243;
+	FIELD field_26286 LIGHT_GRAY Lnet/minecraft/class_1243;
+	FIELD field_26287 CYAN Lnet/minecraft/class_1243;
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 color
 	METHOD method_28085 getRenderColor (I)I
 		ARG 1 shade
+	METHOD method_28086 getBlockColor (Lnet/minecraft/class_4985;)Lnet/minecraft/class_1243;
+		ARG 0 color

--- a/mappings/net/minecraft/block/MaterialColor.mapping
+++ b/mappings/net/minecraft/block/MaterialColor.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_1243 net/minecraft/block/MaterialColor
 	FIELD field_26260 BLACK_TERRACOTTA Lnet/minecraft/class_1243;
 	FIELD field_26261 color I
 	FIELD field_26262 id I
-	FIELD field_26263 BLOCK_COLORS [Lnet/minecraft/class_1243;
+	FIELD field_26263 DYE_COLORS [Lnet/minecraft/class_1243;
 	FIELD field_26264 CLEAR Lnet/minecraft/class_1243;
 	FIELD field_26265 GRASS Lnet/minecraft/class_1243;
 	FIELD field_26266 SAND Lnet/minecraft/class_1243;

--- a/mappings/net/minecraft/block/NonSolidMaterial.mapping
+++ b/mappings/net/minecraft/block/NonSolidMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1240 net/minecraft/block/NonSolidMaterial

--- a/mappings/net/minecraft/block/PortalMaterial.mapping
+++ b/mappings/net/minecraft/block/PortalMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1244 net/minecraft/block/PortalMaterial

--- a/mappings/net/minecraft/block/ReplaceableMaterial.mapping
+++ b/mappings/net/minecraft/block/ReplaceableMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1239 net/minecraft/block/ReplaceableMaterial


### PR DESCRIPTION
Mapped `Material.java` and `MaterialColor.java`. Also mapped the various sub-classes of Material, basically mapped pretty much all material related stuff.

Some controversial names:
`Material.ignoreAdventureMode`
`MaterialColor.getBlockColor(color)` (Not too sure abt this one)