### PR TITLE
[1.7.10] Sprite related mappings

### DIFF
--- a/mappings/net/minecraft/SpriteLoader.mapping
+++ b/mappings/net/minecraft/SpriteLoader.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_2617 net/minecraft/SpriteLoader
+	METHOD method_10535 addSpriteToLoad (Ljava/lang/String;)Lnet/minecraft/class_2616;
+		ARG 1 name

--- a/mappings/net/minecraft/class_2616.mapping
+++ b/mappings/net/minecraft/class_2616.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_2616
+	METHOD method_10526 getWidth ()I
+	METHOD method_10528 getHeight ()I
+	METHOD method_10530 getUMin ()F
+	METHOD method_10531 getUMax ()F
+	METHOD method_10532 getVMin ()F
+	METHOD method_10533 getVMax ()F
+	METHOD method_10534 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/texture/SpriteImpl.mapping
+++ b/mappings/net/minecraft/client/texture/SpriteImpl.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1231 net/minecraft/client/texture/Sprite
+CLASS net/minecraft/class_1231 net/minecraft/client/texture/SpriteImpl
 	FIELD field_5130 frames Ljava/util/List;
 	FIELD field_5132 rotation Z
 	FIELD field_5133 x I

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -24,6 +24,8 @@ CLASS net/minecraft/class_2054 net/minecraft/item/Item
 	FIELD field_8640 translationKey Ljava/lang/String;
 		COMMENT The Item's translation key.
 	FIELD field_8884 REGISTRY Lnet/minecraft/class_1393;
+	FIELD field_8885 sprite Lnet/minecraft/class_2616;
+	FIELD field_8886 spriteName Ljava/lang/String;
 	METHOD <init> ()V
 		COMMENT Sets the max stack size of an Item to 64
 	METHOD method_8246 getTranslationKey ()Ljava/lang/String;
@@ -244,3 +246,8 @@ CLASS net/minecraft/class_2054 net/minecraft/item/Item
 		COMMENT Returns whether the item is supposed to look as handheld.
 	METHOD method_8425 byBlock (Lnet/minecraft/class_160;)Lnet/minecraft/class_2054;
 		ARG 0 block
+	METHOD method_8426 addSpritesToLoad (Lnet/minecraft/class_2617;)V
+		ARG 1 loader
+	METHOD method_8430 setSpriteName (Ljava/lang/String;)Lnet/minecraft/class_2054;
+		ARG 1 spriteName
+	METHOD method_8433 getSpriteName ()Ljava/lang/String;

--- a/mappings/oshi/hardware/Processor.mapping
+++ b/mappings/oshi/hardware/Processor.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2616 oshi/hardware/Processor


### PR DESCRIPTION
Hello, I have mapped some sprite-related classes and methods

Todo: rename `net/minecraft/class_2616` to `net/minecraft/client/texture/Sprite`