### PR TITLE
Map world connection methods and args

### DIFF
--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -127,7 +127,11 @@ CLASS net/minecraft/class_669 net/minecraft/client/MinecraftClient
 		ARG 1 screen
 	METHOD method_2254 crash (Lnet/minecraft/class_825;)V
 		ARG 1 crashReport
-	METHOD method_2255 disconnect (Lnet/minecraft/class_907;)V
+	METHOD method_2255 connect (Lnet/minecraft/class_907;)V
+		ARG 1 world
+	METHOD method_2256 connect (Lnet/minecraft/class_907;Ljava/lang/String;)V
+		ARG 1 world
+		ARG 2 loadingMessage
 	METHOD method_2257 setCurrentServerEntry (Lnet/minecraft/class_910;)V
 		ARG 1 info
 	METHOD method_2258 loadLogo (Lnet/minecraft/class_1232;)V


### PR DESCRIPTION
The previous name `disconnect` is rather misleading, as these methods actually disconnect from the current world but also connect to the new one, if not null. 
In case you have a better name than `connect` please give suggestions.