### PR TITLE
Map net.minecraft.resource

### DIFF
--- a/mappings/net/minecraft/resource/AbstractFileResourcePack.mapping
+++ b/mappings/net/minecraft/resource/AbstractFileResourcePack.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/class_1245 net/minecraft/resource/AbstractFileResourcePack
 	FIELD field_5220 base Ljava/io/File;
 	FIELD field_5221 LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD <init> (Ljava/io/File;)V
+		ARG 1 base
+	METHOD method_4338 parseMetadata (Lnet/minecraft/class_1275;Ljava/io/InputStream;Ljava/lang/String;)Lnet/minecraft/class_1273;
+		ARG 0 serializer
+		ARG 1 inputStream
+		ARG 2 key
 	METHOD method_4339 relativize (Ljava/io/File;Ljava/io/File;)Ljava/lang/String;
 		ARG 0 base
 		ARG 1 target
@@ -10,3 +16,5 @@ CLASS net/minecraft/class_1245 net/minecraft/resource/AbstractFileResourcePack
 		ARG 1 name
 	METHOD method_4342 warnNonLowercaseNamespace (Ljava/lang/String;)V
 		ARG 1 namespace
+	METHOD method_4343 getFilename (Lnet/minecraft/class_1605;)Ljava/lang/String;
+		ARG 0 id

--- a/mappings/net/minecraft/resource/DefaultResourcePack.mapping
+++ b/mappings/net/minecraft/resource/DefaultResourcePack.mapping
@@ -1,2 +1,9 @@
 CLASS net/minecraft/class_1249 net/minecraft/resource/DefaultResourcePack
-	METHOD method_4349 getInputStream (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
+	FIELD field_5226 NAMESPACES Ljava/util/Set;
+	FIELD field_5227 assetsIndex Ljava/util/Map;
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 assetsIndex
+	METHOD method_4349 openFromFile (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
+		ARG 1 id
+	METHOD method_4350 openWithClassLoader (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
+		ARG 1 id

--- a/mappings/net/minecraft/resource/DefaultResourcePack.mapping
+++ b/mappings/net/minecraft/resource/DefaultResourcePack.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1249 net/minecraft/resource/DefaultResourcePack
 	FIELD field_5227 assetsIndex Ljava/util/Map;
 	METHOD <init> (Ljava/util/Map;)V
 		ARG 1 assetsIndex
-	METHOD method_4349 openFromFile (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
+	METHOD method_4349 openFile (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
 		ARG 1 id
-	METHOD method_4350 openWithClassLoader (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
+	METHOD method_4350 openClassLoader (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
 		ARG 1 id

--- a/mappings/net/minecraft/resource/ReloadableResourceManager.mapping
+++ b/mappings/net/minecraft/resource/ReloadableResourceManager.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_1256 net/minecraft/resource/ReloadableResourceManager
 	METHOD method_4356 registerListener (Lnet/minecraft/class_1259;)V
 		ARG 1 listener
+	METHOD method_4357 reload (Ljava/util/List;)V
+		ARG 1 resourcePacks

--- a/mappings/net/minecraft/resource/ReloadableResourceManagerImpl.mapping
+++ b/mappings/net/minecraft/resource/ReloadableResourceManagerImpl.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1264 net/minecraft/resource/ReloadableResourceManagerInstance
+CLASS net/minecraft/class_1264 net/minecraft/resource/ReloadableResourceManagerImpl
 	FIELD field_5261 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_5262 JOINER Lcom/google/common/base/Joiner;
 	FIELD field_5263 fallbackManagers Ljava/util/Map;

--- a/mappings/net/minecraft/resource/ReloadableResourceManagerInstance.mapping
+++ b/mappings/net/minecraft/resource/ReloadableResourceManagerInstance.mapping
@@ -1,2 +1,16 @@
 CLASS net/minecraft/class_1264 net/minecraft/resource/ReloadableResourceManagerInstance
 	FIELD field_5261 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_5262 JOINER Lcom/google/common/base/Joiner;
+	FIELD field_5263 fallbackManagers Ljava/util/Map;
+	FIELD field_5264 listeners Ljava/util/List;
+	FIELD field_5265 namespaces Ljava/util/Set;
+	FIELD field_5266 metaSerializer Lnet/minecraft/class_1275;
+	METHOD <init> (Lnet/minecraft/class_1275;)V
+		ARG 1 metaSerializer
+	METHOD method_4392 add (Lnet/minecraft/class_1260;)V
+		ARG 1 pack
+	METHOD method_4393 clear ()V
+	METHOD method_4394 notifyListeners ()V
+	CLASS 1
+		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 pack

--- a/mappings/net/minecraft/resource/Resource.mapping
+++ b/mappings/net/minecraft/resource/Resource.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_1257 net/minecraft/resource/Resource
 	METHOD method_4358 getId ()Lnet/minecraft/class_1605;
+	METHOD method_4359 getMetadata (Ljava/lang/String;)Lnet/minecraft/class_1273;
+		ARG 1 key
 	METHOD method_4360 getInputStream ()Ljava/io/InputStream;
+	METHOD method_4361 hasMetadata ()Z
 	METHOD method_4362 getResourcePackName ()Ljava/lang/String;

--- a/mappings/net/minecraft/resource/ResourceImpl.mapping
+++ b/mappings/net/minecraft/resource/ResourceImpl.mapping
@@ -1,6 +1,17 @@
 CLASS net/minecraft/class_1265 net/minecraft/resource/ResourceImpl
+	FIELD field_5268 metaProviders Ljava/util/Map;
 	FIELD field_5269 packName Ljava/lang/String;
+	FIELD field_5270 id Lnet/minecraft/class_1605;
 	FIELD field_5271 inputStream Ljava/io/InputStream;
 	FIELD field_5272 metaInputStream Ljava/io/InputStream;
+	FIELD field_5273 metaSerializer Lnet/minecraft/class_1275;
 	FIELD field_5274 readMetadata Z
 	FIELD field_5275 metadata Lcom/google/gson/JsonObject;
+	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_1605;Ljava/io/InputStream;Ljava/io/InputStream;Lnet/minecraft/class_1275;)V
+		ARG 1 packName
+		ARG 2 id
+		ARG 3 inputStream
+		ARG 4 metaInputStream
+		ARG 5 metaSerializer
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 o

--- a/mappings/net/minecraft/resource/ResourceManager.mapping
+++ b/mappings/net/minecraft/resource/ResourceManager.mapping
@@ -2,3 +2,5 @@ CLASS net/minecraft/class_1258 net/minecraft/resource/ResourceManager
 	METHOD method_4363 getAllNamespaces ()Ljava/util/Set;
 	METHOD method_4364 getResource (Lnet/minecraft/class_1605;)Lnet/minecraft/class_1257;
 		ARG 1 id
+	METHOD method_4365 getAllResources (Lnet/minecraft/class_1605;)Ljava/util/List;
+		ARG 1 id

--- a/mappings/net/minecraft/resource/ResourceNotFoundException.mapping
+++ b/mappings/net/minecraft/resource/ResourceNotFoundException.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_1261 net/minecraft/resource/ResourceNotFoundException
+	METHOD <init> (Ljava/io/File;Ljava/lang/String;)V
+		ARG 1 packSource
+		ARG 2 resource

--- a/mappings/net/minecraft/resource/ResourcePack.mapping
+++ b/mappings/net/minecraft/resource/ResourcePack.mapping
@@ -1,2 +1,11 @@
 CLASS net/minecraft/class_1260 net/minecraft/resource/ResourcePack
+	METHOD method_4367 getIcon ()Ljava/awt/image/BufferedImage;
+	METHOD method_4368 parseMetadata (Lnet/minecraft/class_1275;Ljava/lang/String;)Lnet/minecraft/class_1273;
+		ARG 1 serializer
+		ARG 2 key
+	METHOD method_4369 open (Lnet/minecraft/class_1605;)Ljava/io/InputStream;
+		ARG 1 id
 	METHOD method_4370 getName ()Ljava/lang/String;
+	METHOD method_4371 contains (Lnet/minecraft/class_1605;)Z
+		ARG 1 id
+	METHOD method_4372 getNamespaces ()Ljava/util/Set;

--- a/mappings/net/minecraft/resource/ZipResourcePack.mapping
+++ b/mappings/net/minecraft/resource/ZipResourcePack.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1252 net/minecraft/resource/ZipResourcePack
 	FIELD field_5234 TYPE_NAMESPACE_SPLITTER Lcom/google/common/base/Splitter;
 	FIELD field_5235 file Ljava/util/zip/ZipFile;
+	METHOD close ()V
 	METHOD method_4355 getZipFile ()Ljava/util/zip/ZipFile;


### PR DESCRIPTION
More "breaking changes" through the rename of `DefaultResourcePack#getInputStream` and `ReloadableResourceManagerInstance`, but they seemed fitting.