### PR TITLE
1.12.2 map some of the datafixer stuff

### DIFF
--- a/mappings/net/minecraft/class_2934.mapping
+++ b/mappings/net/minecraft/class_2934.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_2934
-	METHOD method_12900 (Lnet/minecraft/class_2931;Lnet/minecraft/class_322;)Lnet/minecraft/class_322;
-		ARG 2 tag
-	METHOD method_12903 (Lnet/minecraft/class_2932;Lnet/minecraft/class_2936;)V
-		ARG 1 type
-	METHOD method_12904 (Lnet/minecraft/class_2931;Lnet/minecraft/class_322;I)Lnet/minecraft/class_322;
-		ARG 2 tag

--- a/mappings/net/minecraft/datafix/BedDataFixer.mapping
+++ b/mappings/net/minecraft/datafix/BedDataFixer.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_3359 net/minecraft/datafix/BedDataFixer
-	FIELD field_16491 LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/datafix/class_3360.mapping
+++ b/mappings/net/minecraft/datafix/class_3360.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_3360 net/minecraft/datafix/class_3360

--- a/mappings/net/minecraft/datafixer/DataFixer.mapping
+++ b/mappings/net/minecraft/datafixer/DataFixer.mapping
@@ -1,2 +1,2 @@
-CLASS net/minecraft/class_2930 net/minecraft/datafix/DataFixer
+CLASS net/minecraft/class_2930 net/minecraft/datafixer/DataFixer
 	METHOD method_12887 datafix (Lnet/minecraft/class_322;)Lnet/minecraft/class_322;

--- a/mappings/net/minecraft/datafixer/class_2934.mapping
+++ b/mappings/net/minecraft/datafixer/class_2934.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_2934 net/minecraft/datafixer/class_2934
+	FIELD field_14397 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_14400 dataVersion I
+	METHOD <init> (I)V
+		ARG 1 dataVersion
+	METHOD method_12900 (Lnet/minecraft/class_2931;Lnet/minecraft/class_322;)Lnet/minecraft/class_322;
+		ARG 2 tag
+	METHOD method_12903 (Lnet/minecraft/class_2932;Lnet/minecraft/class_2936;)V
+		ARG 1 type
+	METHOD method_12904 (Lnet/minecraft/class_2931;Lnet/minecraft/class_322;I)Lnet/minecraft/class_322;
+		ARG 2 tag

--- a/mappings/net/minecraft/datafixer/fix/BedDataFixer.mapping
+++ b/mappings/net/minecraft/datafixer/fix/BedDataFixer.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_3359 net/minecraft/datafixer/fix/BedDataFixer
+	FIELD field_16491 LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/datafixer/fix/BedItemDataFixer.mapping
+++ b/mappings/net/minecraft/datafixer/fix/BedItemDataFixer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_3360 net/minecraft/datafixer/fix/BedItemDataFixer

--- a/mappings/net/minecraft/datafixer/fix/class_2937.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2937.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2937 net/minecraft/datafixer/fix/class_2937

--- a/mappings/net/minecraft/datafixer/fix/class_2938.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2938.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2938 net/minecraft/datafixer/fix/class_2938

--- a/mappings/net/minecraft/datafixer/fix/class_2939.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2939.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2939 net/minecraft/datafixer/fix/class_2939

--- a/mappings/net/minecraft/datafixer/fix/class_2940.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2940.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2940 net/minecraft/datafixer/fix/class_2940

--- a/mappings/net/minecraft/datafixer/fix/class_2941.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2941.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2941 net/minecraft/datafixer/fix/class_2941

--- a/mappings/net/minecraft/datafixer/fix/class_2942.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2942.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2942 net/minecraft/datafixer/fix/class_2942

--- a/mappings/net/minecraft/datafixer/fix/class_2943.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2943.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2943 net/minecraft/datafixer/fix/class_2943

--- a/mappings/net/minecraft/datafixer/fix/class_2944.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2944.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2944 net/minecraft/datafixer/fix/class_2944

--- a/mappings/net/minecraft/datafixer/fix/class_2945.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2945.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2945 net/minecraft/datafixer/fix/class_2945

--- a/mappings/net/minecraft/datafixer/fix/class_2946.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2946.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2946 net/minecraft/datafixer/fix/class_2946

--- a/mappings/net/minecraft/datafixer/fix/class_2947.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2947.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2947 net/minecraft/datafixer/fix/class_2947

--- a/mappings/net/minecraft/datafixer/fix/class_2948.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2948.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2948 net/minecraft/datafixer/fix/class_2948

--- a/mappings/net/minecraft/datafixer/fix/class_2949.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2949.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2949 net/minecraft/datafixer/fix/class_2949

--- a/mappings/net/minecraft/datafixer/fix/class_2950.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2950.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2950 net/minecraft/datafixer/fix/class_2950

--- a/mappings/net/minecraft/datafixer/fix/class_2951.mapping
+++ b/mappings/net/minecraft/datafixer/fix/class_2951.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2951 net/minecraft/datafixer/fix/class_2951

--- a/mappings/net/minecraft/entity/class_2951.mapping
+++ b/mappings/net/minecraft/entity/class_2951.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2951 net/minecraft/entity/class_2951


### PR DESCRIPTION
this moves the datafixers from `net/minecraft/datafix` to
`net/minecraft/datafixer/fix` (like in 1.19 yarn)

the base DataFixer is then in `net/minecraft/datafixer`

also named the LOGGER and dataVersion in class_2934