### PR TITLE
1.12.2 add the things that masa pointed out (discord)

### DIFF
--- a/mappings/net/minecraft/block/SkullBlock.mapping
+++ b/mappings/net/minecraft/block/SkullBlock.mapping
@@ -1,3 +1,3 @@
-CLASS net/minecraft/class_1305 net/minecraft/block/SkeletonSkullBlock
+CLASS net/minecraft/class_1305 net/minecraft/block/SkullBlock
 	FIELD field_9666 FACING Lnet/minecraft/class_2244;
 	FIELD field_9667 NO_DROP Lnet/minecraft/class_2243;

--- a/mappings/net/minecraft/block/SlabBlock.mapping
+++ b/mappings/net/minecraft/block/SlabBlock.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_143 net/minecraft/block/SlabBlock
-	FIELD field_9472 HALD Lnet/minecraft/class_2245;
+	FIELD field_9472 HALF Lnet/minecraft/class_2245;
 	METHOD method_8794 isDoubleSlab ()Z
 	CLASS class_2192 SlabType
 		FIELD field_9473 TOP Lnet/minecraft/class_143$class_2192;

--- a/mappings/net/minecraft/class_3012.mapping
+++ b/mappings/net/minecraft/class_3012.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_3012
+	METHOD method_13363 create (Lnet/minecraft/class_63;)Lnet/minecraft/class_3012;

--- a/mappings/net/minecraft/util/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/util/PacketByteBuf.mapping
@@ -128,7 +128,7 @@ CLASS net/minecraft/class_1967 net/minecraft/util/PacketByteBuf
 	METHOD method_7422 writeNbtCompound (Lnet/minecraft/class_322;)V
 		ARG 1 nbt
 	METHOD method_7424 readNbtCompound ()Lnet/minecraft/class_322;
-	METHOD method_7425 writeInteger (I)Lnet/minecraft/class_1967;
+	METHOD method_7425 writeVarInt (I)Lnet/minecraft/class_1967;
 		ARG 1 integer
 	METHOD method_7425 writeVarInt (I)V
 		ARG 1 i

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -563,6 +563,7 @@ CLASS net/minecraft/class_1150 net/minecraft/world/World
 	METHOD method_8505 setBlockState (Lnet/minecraft/class_2552;Lnet/minecraft/class_2232;)Z
 		ARG 1 pos
 		ARG 2 state
+	METHOD method_8506 setBlockState (Lnet/minecraft/class_2552;Lnet/minecraft/class_2232;I)Z
 	METHOD method_8507 isRegionLoaded (Lnet/minecraft/class_2552;Lnet/minecraft/class_2552;)Z
 		ARG 1 start
 		ARG 2 end


### PR DESCRIPTION
- rename `SkeletonSkullBlock` to `SkullBlock`, as it also contains the
  other skull types
- rename `SlabBlock.HALD` to `SlabBlock.HALF`, as it's clearly the half
  of a slab block that matters
- name `class_3012#method_13363` `create` as `class_3012` implements a
  `Predicate<BlockState>` like `BlockStatePredicate`, and it's used in
  the same way.
- rename `PacketByteBuf#writeInteger()` to `writeVarInt` as it writes a
  variable lengh integer read by `readVarInt()`. This also avoids
  confusion.
- name `World.method_8506`, it's a setBlockState, just like many others.