### PR TITLE
map .recipe stuff

### DIFF
--- a/mappings/net/minecraft/recipe/RecipeDispatcher.mapping
+++ b/mappings/net/minecraft/recipe/RecipeDispatcher.mapping
@@ -1,6 +1,11 @@
 CLASS net/minecraft/class_1112 net/minecraft/recipe/RecipeDispatcher
+	FIELD field_15683 REGISTRY Lnet/minecraft/class_1943;
+	FIELD field_15684 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_4434 INSTANCE Lnet/minecraft/class_1112;
 	FIELD field_4435 recipes Ljava/util/List;
+	METHOD method_14254 setup ()Z
+	METHOD method_14257 load (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1114;
+	METHOD method_14258 register (Ljava/lang/String;Lnet/minecraft/class_1114;)V
 	METHOD method_3493 getInstance ()Lnet/minecraft/class_1112;
 	METHOD method_3495 registerShapedRecipe (Lnet/minecraft/class_1071;[Ljava/lang/Object;)Lnet/minecraft/class_1115;
 		ARG 1 stack

--- a/mappings/net/minecraft/recipe/ShapedRecipeType.mapping
+++ b/mappings/net/minecraft/recipe/ShapedRecipeType.mapping
@@ -2,3 +2,4 @@ CLASS net/minecraft/class_1115 net/minecraft/recipe/ShapedRecipeType
 	FIELD field_4441 result Lnet/minecraft/class_1071;
 	METHOD <init> (II[Lnet/minecraft/class_1071;Lnet/minecraft/class_1071;)V
 		ARG 4 result
+	METHOD method_14265 load (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1115;

--- a/mappings/net/minecraft/recipe/ShapelessRecipeType.mapping
+++ b/mappings/net/minecraft/recipe/ShapelessRecipeType.mapping
@@ -4,3 +4,4 @@ CLASS net/minecraft/class_1116 net/minecraft/recipe/ShapelessRecipeType
 	METHOD <init> (Lnet/minecraft/class_1071;Ljava/util/List;)V
 		ARG 1 result
 		ARG 2 stacks
+	METHOD method_14275 load (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1116;

--- a/mappings/net/minecraft/recipe/TippedArrowRecipeType.mapping
+++ b/mappings/net/minecraft/recipe/TippedArrowRecipeType.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2702 net/minecraft/recipe/TippedArrowRecipeType

--- a/mappings/net/minecraft/recipe/class_2702.mapping
+++ b/mappings/net/minecraft/recipe/class_2702.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2702 net/minecraft/recipe/class_2702


### PR DESCRIPTION
the big question is, should the method that contains the calls to the register method (that actually registers stuff in a registry) be caled `setup` or `register`