### PR TITLE
map EndCityStructure and MansionStructure

### DIFF
--- a/mappings/net/minecraft/structure/EndCityStructure.mapping
+++ b/mappings/net/minecraft/structure/EndCityStructure.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_2757 net/minecraft/structure/EndCityStructure
+	CLASS class_2758 EndCityGeneratorConfig

--- a/mappings/net/minecraft/structure/MansionStructure.mapping
+++ b/mappings/net/minecraft/structure/MansionStructure.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_3070 net/minecraft/structure/MansionStructure
+	CLASS class_3071 MansionGeneratorConfig

--- a/mappings/net/minecraft/structure/class_2757.mapping
+++ b/mappings/net/minecraft/structure/class_2757.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2757 net/minecraft/structure/class_2757

--- a/mappings/net/minecraft/structure/class_2759.mapping
+++ b/mappings/net/minecraft/structure/class_2759.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_2759 net/minecraft/structure/class_2759
+	METHOD method_11834 registerPieces ()V

--- a/mappings/net/minecraft/structure/class_2763.mapping
+++ b/mappings/net/minecraft/structure/class_2763.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2763
+CLASS net/minecraft/class_2763 net/minecraft/structure/class_2763
 	METHOD method_11861 (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_1653;)Lnet/minecraft/class_2765;
 		ARG 1 server
 	METHOD method_13384 (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_1653;)Lnet/minecraft/class_2765;

--- a/mappings/net/minecraft/structure/class_3072.mapping
+++ b/mappings/net/minecraft/structure/class_3072.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_3072 net/minecraft/structure/class_3072
+	METHOD method_13777 registerPieces ()V


### PR DESCRIPTION
(with EndCityGeneratorConfig and MansionGeneratorConfig ofc)

also move the structure related class_2763 in the package
this class does something with looking up .nbt files and loading them
(that stuff should probably be in some subpackage of structure)