### PR TITLE
Correct wrongly named class PassiveBeeSoundInstance

### DIFF
--- a/mappings/net/minecraft/client/render/world/VboChunkRenderManager.mapping
+++ b/mappings/net/minecraft/client/render/world/VboChunkRenderManager.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2425 net/minecraft/client/render/world/VboChunkRenderManager

--- a/mappings/net/minecraft/client/sound/PassiveBeeSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/PassiveBeeSoundInstance.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2425 net/minecraft/client/sound/PassiveBeeSoundInstance


### PR DESCRIPTION
Corrects the wrongly named `PassiveBeeSoundInstance` to a more suitably named `VboChunkRenderManager`.

`PassiveBeeSoundInstance` extends `AbstractChunkRenderManager` with its nearest sibling
being `ListedChunkRenderManager` and is only used if the option "use VBOs" is enabled.

See `WorldRenderer` for usage