### PR TITLE
Unpick a few OpenGL constants in `Tessellator`

### DIFF
--- a/unpick-definitions/gl11.unpick
+++ b/unpick-definitions/gl11.unpick
@@ -1,0 +1,14 @@
+v2
+
+# GL11.glEnableClientState(3288X) that appear in Tessellator#end, for example
+constant gl_client_state org/lwjgl/opengl/GL11 GL_VERTEX_ARRAY
+constant gl_client_state org/lwjgl/opengl/GL11 GL_NORMAL_ARRAY
+constant gl_client_state org/lwjgl/opengl/GL11 GL_COLOR_ARRAY 
+constant gl_client_state org/lwjgl/opengl/GL11 GL_TEXTURE_COORD_ARRAY 
+constant gl_client_state org/lwjgl/opengl/GL11 GL_EDGE_FLAG_ARRAY
+constant gl_client_state org/lwjgl/opengl/GL11 GL_INDEX_ARRAY
+
+target_method org/lwjgl/opengl/GL11 glEnableClientState (I)V
+	param 0 gl_client_state 
+target_method org/lwjgl/opengl/GL11 glDisableClientState (I)V
+	param 0 gl_client_state 


### PR DESCRIPTION
While it's not much, any unpick file should fix `genSources` crash