### PR TITLE
Revert some broken realms mappings

### DIFF
--- a/mappings/net/minecraft/realms/DisconnectedRealmsScreen.mapping
+++ b/mappings/net/minecraft/realms/DisconnectedRealmsScreen.mapping
@@ -1,5 +1,4 @@
 CLASS net/minecraft/realms/DisconnectedRealmsScreen
-	FIELD title title Ljava/lang/String;
 	METHOD <init> (Lnet/minecraft/realms/RealmsScreen;Ljava/lang/String;Lnet/minecraft/class_1982;)V
 		ARG 1 parent
 		ARG 2 title

--- a/mappings/net/minecraft/realms/RealmsAnvilLevelStorageSource.mapping
+++ b/mappings/net/minecraft/realms/RealmsAnvilLevelStorageSource.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/realms/RealmsAnvilLevelStorageSource net/minecraft/realms/RealmsAnvilLevelStorageSource
+CLASS net/minecraft/realms/RealmsAnvilLevelStorageSource
 	METHOD convertLevel (Ljava/lang/String;Lnet/minecraft/class_841;)Z
 		ARG 1 worldName
 		ARG 2 progressListener

--- a/mappings/net/minecraft/realms/RealmsBridge.mapping
+++ b/mappings/net/minecraft/realms/RealmsBridge.mapping
@@ -1,7 +1,5 @@
 CLASS net/minecraft/realms/RealmsBridge
-	FIELD LOGGER LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD previousScreen parent Lnet/minecraft/class_388;
-	METHOD getNotificationScreen getNotificationScreen (Lnet/minecraft/class_388;)Lnet/minecraft/class_1809;
+	METHOD getNotificationScreen (Lnet/minecraft/class_388;)Lnet/minecraft/class_1809;
 		ARG 1 parent
-	METHOD switchToRealms switchToRealms (Lnet/minecraft/class_388;)V
+	METHOD switchToRealms (Lnet/minecraft/class_388;)V
 		ARG 1 parent

--- a/mappings/net/minecraft/realms/RealmsButton.mapping
+++ b/mappings/net/minecraft/realms/RealmsButton.mapping
@@ -1,5 +1,4 @@
-CLASS net/minecraft/realms/RealmsButton net/minecraft/realms/RealmsButton
-	FIELD WIDGETS_LOCATION WIDGETS_LOCATION Lnet/minecraft/class_1653;
+CLASS net/minecraft/realms/RealmsButton
 	FIELD proxy button Lnet/minecraft/class_1808;
 	FIELD proxy widget Lnet/minecraft/class_1808;
 	FIELD proxy widget Lnet/minecraft/class_1808;
@@ -22,19 +21,19 @@ CLASS net/minecraft/realms/RealmsButton net/minecraft/realms/RealmsButton
 		ARG 2 x
 		ARG 3 y
 		ARG 4 message
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active isActive ()Z
-	METHOD active setActive (Z)V
+	METHOD active (Z)V
 		ARG 1 active
-	METHOD blit drawTexture (IIIIII)V
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD active isActive ()Z
+	METHOD blit (IIIIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 u
@@ -71,7 +70,6 @@ CLASS net/minecraft/realms/RealmsButton net/minecraft/realms/RealmsButton
 	METHOD clicked mouseClicked (II)V
 		ARG 1 mouseX
 		ARG 2 mouseY
-	METHOD getHeight getHeight ()I
 	METHOD getProxy getButton ()Lnet/minecraft/class_356;
 	METHOD getProxy getButton ()Lnet/minecraft/class_356;
 	METHOD getProxy getButton ()Lnet/minecraft/class_356;
@@ -82,14 +80,13 @@ CLASS net/minecraft/realms/RealmsButton net/minecraft/realms/RealmsButton
 	METHOD getProxy getButton ()Lnet/minecraft/class_356;
 	METHOD getProxy getButton ()Lnet/minecraft/class_356;
 	METHOD getProxy getButton ()Lnet/minecraft/class_356;
-	METHOD getWidth getWidth ()I
-	METHOD getYImage getDelegateYImage (Z)I
+	METHOD getYImage (Z)I
 		ARG 1 isHovered
 	METHOD method_8149 getId ()I
 	METHOD method_8150 getY ()I
-	METHOD msg setMessage (Ljava/lang/String;)V
+	METHOD msg (Ljava/lang/String;)V
 		ARG 1 message
-	METHOD released mouseReleased (II)V
+	METHOD released (II)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 	METHOD render (II)V
@@ -122,6 +119,6 @@ CLASS net/minecraft/realms/RealmsButton net/minecraft/realms/RealmsButton
 	METHOD render render (II)V
 		ARG 1 mouseX
 		ARG 2 mouseY
-	METHOD renderBg renderBackground (II)V
+	METHOD renderBg (II)V
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/net/minecraft/realms/RealmsClickableScrolledSelectionList.mapping
+++ b/mappings/net/minecraft/realms/RealmsClickableScrolledSelectionList.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/realms/RealmsClickableScrolledSelectionList net/minecraft/realms/RealmsClickableScrolledSelectionList
+CLASS net/minecraft/realms/RealmsClickableScrolledSelectionList
 	FIELD proxy list Lnet/minecraft/class_2311;
 	FIELD proxy widget Lnet/minecraft/class_2311;
 	FIELD proxy widget Lnet/minecraft/class_2311;
@@ -12,19 +12,15 @@ CLASS net/minecraft/realms/RealmsClickableScrolledSelectionList net/minecraft/re
 		ARG 3 top
 		ARG 4 bottom
 		ARG 5 entryHeight
-	METHOD customMouseEvent customMouseEvent (IIIFI)V
+	METHOD customMouseEvent (IIIFI)V
 		ARG 1 yStart
 		ARG 2 yEnd
 		ARG 3 headerHeight
 		ARG 4 scrollAmount
 		ARG 5 entryHeight
-	METHOD getItemCount getItemCount ()I
-	METHOD getMaxPosition getMaxPosition ()I
-	METHOD getScroll getScrollAmount ()I
-	METHOD getScrollbarPosition getScrollbarPosition ()I
-	METHOD isSelectedItem isSelectedItem (I)Z
+	METHOD isSelectedItem (I)Z
 		ARG 1 index
-	METHOD itemClicked itemClicked (IIIII)V
+	METHOD itemClicked (IIIII)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 button
@@ -32,55 +28,11 @@ CLASS net/minecraft/realms/RealmsClickableScrolledSelectionList net/minecraft/re
 		ARG 5 y
 	METHOD method_10807 getLastMouseX ()I
 	METHOD method_10808 getLastMouseY ()I
-	METHOD mouseEvent handleMouse ()V
-	METHOD render render (IIF)V
+	METHOD render (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 tickDelta
-	METHOD renderBackground renderBackground ()V
-	METHOD renderItem renderEntry (IIIIII)V
-		ARG 1 index
-		ARG 2 x
-		ARG 3 y
-		ARG 4 rowHeight
-		ARG 5 mouseX
-		ARG 6 mouseY
-	METHOD renderItem renderEntry (IIIIII)V
-		ARG 1 index
-		ARG 2 x
-		ARG 3 y
-		ARG 4 rowHeight
-		ARG 5 mouseX
-		ARG 6 mouseY
-	METHOD renderItem renderEntry (IIIIII)V
-		ARG 1 index
-		ARG 2 x
-		ARG 3 y
-		ARG 4 rowHeight
-		ARG 5 mouseX
-		ARG 6 mouseY
-	METHOD renderItem renderEntry (IIIIII)V
-		ARG 1 index
-		ARG 2 x
-		ARG 3 y
-		ARG 4 rowHeight
-		ARG 5 mouseX
-		ARG 6 mouseY
-	METHOD renderItem renderEntry (IIIIII)V
-		ARG 1 index
-		ARG 2 x
-		ARG 3 y
-		ARG 4 rowHeight
-		ARG 5 mouseX
-		ARG 6 mouseY
-	METHOD renderItem renderEntry (IIIIII)V
-		ARG 1 index
-		ARG 2 x
-		ARG 3 y
-		ARG 4 rowHeight
-		ARG 5 mouseX
-		ARG 6 mouseY
-	METHOD renderItem renderEntry (IIIILnet/minecraft/realms/Tezzelator;II)V
+	METHOD renderItem (IIIILnet/minecraft/realms/Tezzelator;II)V
 		ARG 1 index
 		ARG 2 x
 		ARG 3 y
@@ -88,23 +40,64 @@ CLASS net/minecraft/realms/RealmsClickableScrolledSelectionList net/minecraft/re
 		ARG 5 tesselator
 		ARG 6 mouseX
 		ARG 7 mouseY
-	METHOD renderList renderList (IIII)V
+	METHOD renderItem renderEntry (IIIIII)V
+		ARG 1 index
+		ARG 2 x
+		ARG 3 y
+		ARG 4 rowHeight
+		ARG 5 mouseX
+		ARG 6 mouseY
+	METHOD renderItem renderEntry (IIIIII)V
+		ARG 1 index
+		ARG 2 x
+		ARG 3 y
+		ARG 4 rowHeight
+		ARG 5 mouseX
+		ARG 6 mouseY
+	METHOD renderItem renderEntry (IIIIII)V
+		ARG 1 index
+		ARG 2 x
+		ARG 3 y
+		ARG 4 rowHeight
+		ARG 5 mouseX
+		ARG 6 mouseY
+	METHOD renderItem renderEntry (IIIIII)V
+		ARG 1 index
+		ARG 2 x
+		ARG 3 y
+		ARG 4 rowHeight
+		ARG 5 mouseX
+		ARG 6 mouseY
+	METHOD renderItem renderEntry (IIIIII)V
+		ARG 1 index
+		ARG 2 x
+		ARG 3 y
+		ARG 4 rowHeight
+		ARG 5 mouseX
+		ARG 6 mouseY
+	METHOD renderItem renderEntry (IIIIII)V
+		ARG 1 index
+		ARG 2 x
+		ARG 3 y
+		ARG 4 rowHeight
+		ARG 5 mouseX
+		ARG 6 mouseY
+	METHOD renderList (IIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 mouseX
 		ARG 4 mouseY
-	METHOD renderSelected renderSelected (IIILnet/minecraft/realms/Tezzelator;)V
+	METHOD renderSelected (IIILnet/minecraft/realms/Tezzelator;)V
 		ARG 1 width
 		ARG 2 height
 		ARG 3 textHeight
 		ARG 4 tesselator
-	METHOD scroll scroll (I)V
+	METHOD scroll (I)V
 		ARG 1 amount
-	METHOD selectItem selectItem (IZII)V
+	METHOD selectItem (IZII)V
 		ARG 1 index
 		ARG 2 doubleClick
 		ARG 3 lastMouseX
 		ARG 4 lastMouseY
-	METHOD setLeftPos setXPos (I)V
+	METHOD setLeftPos (I)V
 		ARG 1 x
-	METHOD width getWidth ()I

--- a/mappings/net/minecraft/realms/RealmsEditBox.mapping
+++ b/mappings/net/minecraft/realms/RealmsEditBox.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/realms/RealmsEditBox net/minecraft/realms/RealmsEditBox
+CLASS net/minecraft/realms/RealmsEditBox
 	FIELD editBox Lnet/minecraft/class_367;
 	METHOD <init> (IIIII)V
 		ARG 1 id

--- a/mappings/net/minecraft/realms/RealmsScreen.mapping
+++ b/mappings/net/minecraft/realms/RealmsScreen.mapping
@@ -1,16 +1,4 @@
-CLASS net/minecraft/realms/RealmsScreen net/minecraft/realms/RealmsScreen
-	FIELD SKIN_HAT_HEIGHT SKIN_HAT_HEIGHT I
-	FIELD SKIN_HAT_U SKIN_HAT_U I
-	FIELD SKIN_HAT_V SKIN_HAT_V I
-	FIELD SKIN_HAT_WIDTH SKIN_HAT_WIDTH I
-	FIELD SKIN_HEAD_HEIGHT SKIN_HEAD_HEIGHT I
-	FIELD SKIN_HEAD_U SKIN_HEAD_U I
-	FIELD SKIN_HEAD_V SKIN_HEAD_V I
-	FIELD SKIN_HEAD_WIDTH SKIN_HEAD_WIDTH I
-	FIELD SKIN_TEX_HEIGHT SKIN_TEX_HEIGHT I
-	FIELD SKIN_TEX_WIDTH SKIN_TEX_WIDTH I
-	FIELD height height I
-	FIELD minecraft client Lnet/minecraft/class_1600;
+CLASS net/minecraft/realms/RealmsScreen
 	FIELD proxy proxy Lnet/minecraft/class_1809;
 	FIELD proxy proxy Lnet/minecraft/class_1809;
 	FIELD proxy proxy Lnet/minecraft/class_1809;
@@ -20,10 +8,9 @@ CLASS net/minecraft/realms/RealmsScreen net/minecraft/realms/RealmsScreen
 	FIELD proxy proxy Lnet/minecraft/class_1809;
 	FIELD proxy proxy Lnet/minecraft/class_1809;
 	FIELD proxy proxy Lnet/minecraft/class_1809;
-	FIELD width width I
-	METHOD bind bindTexture (Ljava/lang/String;)V
+	METHOD bind (Ljava/lang/String;)V
 		ARG 0 id
-	METHOD bindFace bindTexture (Ljava/lang/String;Ljava/lang/String;)V
+	METHOD bindFace (Ljava/lang/String;Ljava/lang/String;)V
 		ARG 0 uuid
 		ARG 1 playerName
 	METHOD blit (IIFFIIFF)V
@@ -44,293 +31,287 @@ CLASS net/minecraft/realms/RealmsScreen net/minecraft/realms/RealmsScreen
 		ARG 7 height
 		ARG 8 textureWidth
 		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 width
-		ARG 5 height
-		ARG 6 textureWidth
-		ARG 7 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIFFIIIIFF)V
-		ARG 0 x
-		ARG 1 y
-		ARG 2 u
-		ARG 3 v
-		ARG 4 regionWidth
-		ARG 5 regionHeight
-		ARG 6 width
-		ARG 7 height
-		ARG 8 textureWidth
-		ARG 9 textureHeight
-	METHOD blit drawTexture (IIIIII)V
+	METHOD blit (IIIIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 u
 		ARG 4 v
 		ARG 5 width
 		ARG 6 height
-	METHOD buttonClicked buttonClicked (Lnet/minecraft/realms/RealmsButton;)V
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 width
+		ARG 5 height
+		ARG 6 textureWidth
+		ARG 7 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD blit drawTexture (IIFFIIIIFF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 u
+		ARG 3 v
+		ARG 4 regionWidth
+		ARG 5 regionHeight
+		ARG 6 width
+		ARG 7 height
+		ARG 8 textureWidth
+		ARG 9 textureHeight
+	METHOD buttonClicked (Lnet/minecraft/realms/RealmsButton;)V
 		ARG 1 realmsButton
-	METHOD buttons getButtons ()Ljava/util/List;
-	METHOD buttonsAdd addButton (Lnet/minecraft/realms/RealmsButton;)V
+	METHOD buttonsAdd (Lnet/minecraft/realms/RealmsButton;)V
 		ARG 1 button
-	METHOD buttonsClear clear ()V
-	METHOD buttonsRemove removeButton (Lnet/minecraft/realms/RealmsButton;)V
+	METHOD buttonsRemove (Lnet/minecraft/realms/RealmsButton;)V
 		ARG 1 button
-	METHOD confirmResult confirmResult (ZI)V
+	METHOD confirmResult (ZI)V
 		ARG 1 confirmed
 		ARG 2 id
-	METHOD drawCenteredString drawCenteredString (Ljava/lang/String;III)V
+	METHOD drawCenteredString (Ljava/lang/String;III)V
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
 		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;III)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-		ARG 4 color
-	METHOD drawString drawString (Ljava/lang/String;IIIZ)V
+	METHOD drawString (Ljava/lang/String;IIIZ)V
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
 		ARG 4 color
 		ARG 5 shadow
-	METHOD fillGradient fillGradient (IIIIII)V
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD drawString drawString (Ljava/lang/String;III)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+	METHOD fillGradient (IIIIII)V
 		ARG 1 x1
 		ARG 2 y1
 		ARG 3 x2
 		ARG 4 y2
 		ARG 5 color1
 		ARG 6 color2
-	METHOD fontDrawShadow fontDrawShadow (Ljava/lang/String;III)V
+	METHOD fontDrawShadow (Ljava/lang/String;III)V
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
 		ARG 4 color
-	METHOD fontLineHeight getFontHeight ()I
-	METHOD fontSplit wrapLines (Ljava/lang/String;I)Ljava/util/List;
+	METHOD fontSplit (Ljava/lang/String;I)Ljava/util/List;
 		ARG 1 text
 		ARG 2 i
-	METHOD fontWidth getStringWidth (Ljava/lang/String;)I
+	METHOD fontWidth (Ljava/lang/String;)I
 		ARG 1 text
-	METHOD getLevelStorageSource getLevelStorageSource ()Lnet/minecraft/realms/RealmsAnvilLevelStorageSource;
 	METHOD getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 key
-	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
-		ARG 0 string
-	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
-		ARG 0 string
-	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
-		ARG 0 string
-	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
-		ARG 0 string
-	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+	METHOD getLocalizedString (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
 		ARG 0 key
 		ARG 1 args
-	METHOD getLocalizedString translate (Ljava/lang/String;)Ljava/lang/String;
+	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 string
+	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 string
+	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 string
+	METHOD getLocalizedString getLocalizedString (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 string
 	METHOD getLocalizedString translate (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 string
@@ -340,35 +321,32 @@ CLASS net/minecraft/realms/RealmsScreen net/minecraft/realms/RealmsScreen
 		ARG 0 string
 	METHOD getLocalizedString translate (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 string
-	METHOD getProxy getProxy ()Lnet/minecraft/class_1809;
-	METHOD height getHeight ()I
-	METHOD init init ()V
-	METHOD init init ()V
-	METHOD init init ()V
-	METHOD init init ()V
-	METHOD init init (Lnet/minecraft/class_1600;II)V
+	METHOD getLocalizedString translate (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 string
+	METHOD init (Lnet/minecraft/class_1600;II)V
 		ARG 1 client
+	METHOD init init ()V
+	METHOD init init ()V
+	METHOD init init ()V
+	METHOD init init ()V
 	METHOD init switchToMinecraft ()V
 	METHOD init switchToMinecraft ()V
 	METHOD init switchToMinecraft ()V
 	METHOD init switchToMinecraft ()V
 	METHOD init switchToMinecraft ()V
-	METHOD isPauseScreen shouldPauseGame ()Z
-	METHOD keyPressed keyPressed (CI)V
+	METHOD keyPressed (CI)V
 		ARG 1 id
 		ARG 2 code
-	METHOD keyboardEvent keyboardEvent ()V
-	METHOD mouseClicked mouseClicked (III)V
+	METHOD mouseClicked (III)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 button
-	METHOD mouseDragged mouseDragged (IIIJ)V
+	METHOD mouseDragged (IIIJ)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 button
 		ARG 4 mouseLastClicked
-	METHOD mouseEvent mouseEvent ()V
-	METHOD mouseReleased mouseReleased (III)V
+	METHOD mouseReleased (III)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 button
@@ -379,39 +357,39 @@ CLASS net/minecraft/realms/RealmsScreen net/minecraft/realms/RealmsScreen
 		ARG 3 width
 		ARG 4 height
 		ARG 5 message
-	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
-		ARG 0 id
-		ARG 1 x
-		ARG 2 y
-		ARG 3 width
-		ARG 4 height
-		ARG 5 label
-	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
-		ARG 0 id
-		ARG 1 x
-		ARG 2 y
-		ARG 3 width
-		ARG 4 height
-		ARG 5 label
-	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
-		ARG 0 id
-		ARG 1 x
-		ARG 2 y
-		ARG 3 width
-		ARG 4 height
-		ARG 5 label
-	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
-		ARG 0 id
-		ARG 1 x
-		ARG 2 y
-		ARG 3 width
-		ARG 4 height
-		ARG 5 label
-	METHOD newButton createButton (IIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
+	METHOD newButton (IIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
 		ARG 0 id
 		ARG 1 x
 		ARG 2 y
 		ARG 3 label
+	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
+		ARG 0 id
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 label
+	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
+		ARG 0 id
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 label
+	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
+		ARG 0 id
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 label
+	METHOD newButton createButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
+		ARG 0 id
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 label
 	METHOD newButton createRealmsButton (IIIIILjava/lang/String;)Lnet/minecraft/realms/RealmsButton;
 		ARG 0 id
 		ARG 1 x
@@ -447,20 +425,18 @@ CLASS net/minecraft/realms/RealmsScreen net/minecraft/realms/RealmsScreen
 		ARG 3 width
 		ARG 4 height
 		ARG 5 text
-	METHOD newEditBox createEditBox (IIIII)Lnet/minecraft/realms/RealmsEditBox;
+	METHOD newEditBox (IIIII)Lnet/minecraft/realms/RealmsEditBox;
 		ARG 1 id
 		ARG 2 x
 		ARG 3 y
 		ARG 4 width
 		ARG 5 height
-	METHOD removed removed ()V
-	METHOD render render (IIF)V
+	METHOD render (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 tickDelta
 	METHOD renderBackground (I)V
 		ARG 1 alpha
-	METHOD renderBackground renderBackground ()V
 	METHOD renderBackground renderBackground (I)V
 		ARG 1 alpha
 	METHOD renderBackground renderBackground (I)V
@@ -487,81 +463,79 @@ CLASS net/minecraft/realms/RealmsScreen net/minecraft/realms/RealmsScreen
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
-		ARG 1 text
-		ARG 2 x
-		ARG 3 y
-	METHOD renderTooltip renderTooltip (Lnet/minecraft/class_1071;II)V
+	METHOD renderTooltip (Lnet/minecraft/class_1071;II)V
 		ARG 1 stack
 		ARG 2 x
 		ARG 3 y
-	METHOD tick tick ()V
-	METHOD width getWidth ()I
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/lang/String;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+	METHOD renderTooltip renderTooltip (Ljava/util/List;II)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y

--- a/mappings/net/minecraft/realms/RealmsScrolledSelectionList.mapping
+++ b/mappings/net/minecraft/realms/RealmsScrolledSelectionList.mapping
@@ -1,13 +1,10 @@
-CLASS net/minecraft/realms/RealmsScrolledSelectionList net/minecraft/realms/RealmsScrolledSelectionList
-	METHOD getItemCount getEntryCount ()I
-	METHOD getMaxPosition getMaxPosition ()I
-	METHOD getScrollbarPosition getScrollbarPosition ()I
-	METHOD isSelectedItem isEntrySelected (I)Z
+CLASS net/minecraft/realms/RealmsScrolledSelectionList
+	METHOD method_8151 getLastMouseX ()I
+	METHOD method_8152 getLastMouseY ()I
 	METHOD render (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 delta
-	METHOD renderBackground renderBackground ()V
 	METHOD renderItem renderEntry (IIIIII)V
 	METHOD renderItem renderEntry (IIIIII)V
 	METHOD renderItem renderEntry (IIIIII)V
@@ -15,4 +12,3 @@ CLASS net/minecraft/realms/RealmsScrolledSelectionList net/minecraft/realms/Real
 	METHOD renderItem renderEntry (IIIIII)V
 	METHOD scroll (I)V
 		ARG 1 amount
-	METHOD selectItem selectEntry (IZII)V

--- a/mappings/net/minecraft/realms/RealmsSimpleScrolledSelectionList.mapping
+++ b/mappings/net/minecraft/realms/RealmsSimpleScrolledSelectionList.mapping
@@ -1,22 +1,16 @@
-CLASS net/minecraft/realms/RealmsSimpleScrolledSelectionList net/minecraft/realms/RealmsSimpleScrolledSelectionList
+CLASS net/minecraft/realms/RealmsSimpleScrolledSelectionList
 	METHOD <init> (IIIII)V
 		ARG 1 width
 		ARG 2 height
 		ARG 3 top
 		ARG 4 bottom
 		ARG 5 entryHeight
-	METHOD getItemCount getEntryCount ()I
-	METHOD getMaxPosition getMaxPosition ()I
-	METHOD getScrollbarPosition getScrollbarPosition ()I
-	METHOD isSelectedItem isEntrySelected (I)Z
 	METHOD method_10809 getLastMouseX ()I
 	METHOD method_10810 getLastMouseY ()I
 	METHOD render (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 delta
-	METHOD renderBackground renderBackground ()V
 	METHOD renderItem renderEntry (IIIIII)V
 	METHOD scroll (I)V
 		ARG 1 amount
-	METHOD selectItem selectItem (IZII)V

--- a/mappings/net/minecraft/realms/Tezzelator.mapping
+++ b/mappings/net/minecraft/realms/Tezzelator.mapping
@@ -1,6 +1,5 @@
-CLASS net/minecraft/realms/Tezzelator net/minecraft/realms/RealmsTesselator
-	FIELD field_8913 tesselator Lnet/minecraft/class_533;
-	FIELD instance INSTANCE Lnet/minecraft/realms/Tezzelator;
+CLASS net/minecraft/realms/Tezzelator
+	FIELD field_8913 tessellator Lnet/minecraft/class_533;
 	METHOD begin (ILnet/minecraft/realms/RealmsVertexFormat;)V
 		ARG 1 drawMode
 		ARG 2 format


### PR DESCRIPTION
The realms library is not remapped so there are exceptions when it tries to invoke some methods. Here I have assumed that every method that wasn't obfuscated by Mojang is used in the library.

I don't think any mod developers use this package anyway (realms doesn't even work) so maybe deleting it would be better...