### PR TITLE
Revert some changes of #272

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -19,6 +19,7 @@
     // words - list of words to be always considered correct
     "words": [
         "alloc",
+        "arbMultitexture",
         "attackable",
         "authlib",
         "BIOMESET",
@@ -162,6 +163,7 @@
         "teleporter",
         "teleporting",
         "tessellator",
+        "textarget",
         "tezzelator",
         "tickable",
         "tickables",

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -45,6 +45,7 @@
         "Decryptor",
         "deflater",
         "deop",
+        "derelativizeId",
         "despawn",
         "dont",
         "DOWNLEFT",

--- a/mappings/com/mojang/blaze3d/platform/GLX.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GLX.mapping
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_629 com/mojang/blaze3d/platform/GLX
 	FIELD field_11421 source0Rgb I
 	FIELD field_2300 textureUnit I
 	FIELD field_2301 lightmapTextureUnit I
-	FIELD field_2302 arbMultiTexture Z
+	FIELD field_2302 arbMultitexture Z
 	FIELD field_8370 gl14Supported Z
 	FIELD field_8371 contextDescription Ljava/lang/String;
 	FIELD field_8372 gl21Supported Z
@@ -98,7 +98,7 @@ CLASS net/minecraft/class_629 com/mojang/blaze3d/platform/GLX
 		COMMENT Attaches a level of a texture object as a logical buffer of a framebuffer object
 		ARG 0 target
 		ARG 1 attachment
-		ARG 2 textTarget
+		ARG 2 textarget
 		ARG 3 texture
 		ARG 4 level
 	METHOD method_7284 gl20GetUniformLocation (ILjava/lang/CharSequence;)I

--- a/mappings/net/minecraft/client/render/model/ModelLoader.mapping
+++ b/mappings/net/minecraft/client/render/model/ModelLoader.mapping
@@ -28,5 +28,5 @@ CLASS net/minecraft/class_2531 net/minecraft/client/render/model/ModelLoader
 	METHOD method_10398 getModel (Lnet/minecraft/class_1653;)Lnet/minecraft/class_2445;
 		ARG 1 id
 	METHOD method_10399 load ()V
-	METHOD method_10401 deRelativizeId (Lnet/minecraft/class_1653;)Lnet/minecraft/class_1653;
+	METHOD method_10401 derelativizeId (Lnet/minecraft/class_1653;)Lnet/minecraft/class_1653;
 		ARG 1 id

--- a/mappings/net/minecraft/client/render/model/json/ModelVariantMap.mapping
+++ b/mappings/net/minecraft/client/render/model/json/ModelVariantMap.mapping
@@ -46,7 +46,7 @@ CLASS net/minecraft/class_2449 net/minecraft/client/render/model/json/ModelVaria
 				ARG 3 ctx
 			METHOD method_10039 getRotation (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_2529;
 				ARG 1 json
-			METHOD method_10040 deRelativizeId (Ljava/lang/String;)Lnet/minecraft/class_1653;
+			METHOD method_10040 derelativizeId (Ljava/lang/String;)Lnet/minecraft/class_1653;
 				ARG 1 id
 			METHOD method_10041 getModel (Lcom/google/gson/JsonObject;)Ljava/lang/String;
 				ARG 1 json


### PR DESCRIPTION
As mentioned by Papyrus in #yarn some changes should be reverted.

`arbMultitexture` and `textarget` are the official names for the related opengl functions.
See the docs for [GL_ARB_multitexture](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_multitexture.txt) and [glFramebufferTexture](https://www.khronos.org/opengl/wiki/GLAPI/glFramebufferTexture).

Also reverts `deRelativizeId` back to `derelativizeId`.