### PR TITLE
map gamerule manager

### DIFF
--- a/mappings/net/minecraft/world/GameRuleManager.mapping
+++ b/mappings/net/minecraft/world/GameRuleManager.mapping
@@ -7,8 +7,9 @@ CLASS net/minecraft/class_1439 net/minecraft/world/GameRuleManager
 		ARG 1 name
 	METHOD method_4669 addGameRule (Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/class_1439$class_2166;)V
 		ARG 1 name
-		ARG 2 defaultValue
+		ARG 2 initialValue
 		ARG 3 variableType
+	METHOD method_4670 getGameRuleNames ()[Ljava/lang/String;
 	METHOD method_4671 getBoolean (Ljava/lang/String;)Z
 		ARG 1 name
 	METHOD method_4672 setGameRule (Ljava/lang/String;Ljava/lang/String;)V
@@ -16,22 +17,25 @@ CLASS net/minecraft/class_1439 net/minecraft/world/GameRuleManager
 		ARG 2 value
 	METHOD method_4673 contains (Ljava/lang/String;)Z
 		ARG 1 key
+	METHOD method_8474 isOfType (Ljava/lang/String;Lnet/minecraft/class_1439$class_2166;)Z
+		ARG 1 name
+		ARG 2 variableType
 	METHOD method_8475 getInt (Ljava/lang/String;)I
 		ARG 1 name
 	CLASS class_1440 Value
-		FIELD field_5462 stringDefaultValue Ljava/lang/String;
-		FIELD field_5463 booleanDefaultValue Z
-		FIELD field_5464 intDefaultValue I
-		FIELD field_5465 doubleDefaultValue D
+		FIELD field_5462 stringValue Ljava/lang/String;
+		FIELD field_5463 booleanValue Z
+		FIELD field_5464 intValue I
+		FIELD field_5465 doubleValue D
 		FIELD field_9206 type Lnet/minecraft/class_1439$class_2166;
 		METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_1439$class_2166;)V
-			ARG 1 defaultValue
+			ARG 1 initialValue
 			ARG 2 type
-		METHOD method_4675 getStringDefaultValue ()Ljava/lang/String;
-		METHOD method_4676 setDefaultValue (Ljava/lang/String;)V
+		METHOD method_4675 getStringValue ()Ljava/lang/String;
+		METHOD method_4676 setValue (Ljava/lang/String;)V
 			ARG 1 value
-		METHOD method_4677 getBooleanDefaultValue ()Z
-		METHOD method_8476 getIntDefaultValue ()I
+		METHOD method_4677 getBooleanValue ()Z
+		METHOD method_8476 getIntValue ()I
 		METHOD method_8477 getVariableType ()Lnet/minecraft/class_1439$class_2166;
 	CLASS class_2166 VariableType
 		FIELD field_9207 ANY Lnet/minecraft/class_1439$class_2166;


### PR DESCRIPTION
fields, methods, and parameters were erroneously named 'default', however gamerules do not store their default values and their values are mutable

mapped on 1.8.9