### PR TITLE
More 1.3.2 mappings (no sendMessage mappings!?!?)

### DIFF
--- a/mappings/net/minecraft/client/Minecraft.mapping
+++ b/mappings/net/minecraft/client/Minecraft.mapping
@@ -1,22 +1,4 @@
 CLASS net/minecraft/client/Minecraft
-	FIELD field_10295 wireFrame Z
-	FIELD field_10296 chunkPath Z
-	FIELD field_10297 chunkVisibility Z
-	FIELD field_10298 chunkCullingEnabled Z
-	FIELD field_10299 twitchPropertyMap Lcom/mojang/authlib/properties/PropertyMap;
-	FIELD field_10300 sessionPropertyMap Lcom/mojang/authlib/properties/PropertyMap;
-	FIELD field_10301 glErrors Z
-	FIELD field_10302 connectedToRealms Z
-	FIELD field_10303 frameTime J
-	FIELD field_10304 modelManager Lnet/minecraft/class_2532;
-	FIELD field_10305 blockRenderManager Lnet/minecraft/class_2430;
-	FIELD field_10306 entityRenderDispatcher Lnet/minecraft/class_550;
-	FIELD field_10307 itemRenderer Lnet/minecraft/class_560;
-	FIELD field_10308 heldItemRenderer Lnet/minecraft/class_529;
-	FIELD field_10309 cameraEntity Lnet/minecraft/class_864;
-	FIELD field_10310 player Lnet/minecraft/class_518;
-	FIELD field_10311 metricsData Lnet/minecraft/class_2601;
-	FIELD field_10312 nanoTime J
 	FIELD field_3759 soundSystem Lnet/minecraft/class_622;
 	FIELD field_3760 mouse Lnet/minecraft/class_345;
 	FIELD field_3761 texturePackManager Lnet/minecraft/class_615;
@@ -108,14 +90,30 @@ CLASS net/minecraft/client/Minecraft
 	FIELD field_7628 mojang Lnet/minecraft/class_1653;
 	FIELD field_7629 sessionService Lcom/mojang/authlib/minecraft/MinecraftSessionService;
 	FIELD field_7630 targetedEntity Lnet/minecraft/class_864;
+	FIELD field_10295 wireFrame Z
+	FIELD field_10296 chunkPath Z
+	FIELD field_10297 chunkVisibility Z
+	FIELD field_10298 chunkCullingEnabled Z
+	FIELD field_10299 twitchPropertyMap Lcom/mojang/authlib/properties/PropertyMap;
+	FIELD field_10300 sessionPropertyMap Lcom/mojang/authlib/properties/PropertyMap;
+	FIELD field_10301 glErrors Z
+	FIELD field_10302 connectedToRealms Z
+	FIELD field_10303 frameTime J
+	FIELD field_10304 modelManager Lnet/minecraft/class_2532;
+	FIELD field_10305 blockRenderManager Lnet/minecraft/class_2430;
+	FIELD field_10306 entityRenderDispatcher Lnet/minecraft/class_550;
+	FIELD field_10307 itemRenderer Lnet/minecraft/class_560;
+	FIELD field_10308 heldItemRenderer Lnet/minecraft/class_529;
+	FIELD field_10309 cameraEntity Lnet/minecraft/class_864;
+	FIELD field_10310 player Lnet/minecraft/class_518;
+	FIELD field_10311 metricsData Lnet/minecraft/class_2601;
+	FIELD field_10312 nanoTime J
 	METHOD <init> (Ljava/awt/Canvas;Lnet/minecraft/client/MinecraftApplet;IIZ)V
 		ARG 1 canvas
 		ARG 2 applet
 		ARG 3 width
 		ARG 4 height
 		ARG 5 focusWindow
-	METHOD <init> (Lnet/minecraft/class_2332;)V
-		ARG 1 args
 	METHOD <init> (Lnet/minecraft/class_355;IIZZLjava/io/File;Ljava/io/File;Ljava/io/File;Ljava/net/Proxy;Ljava/lang/String;)V
 		ARG 1 session
 		ARG 2 width
@@ -127,6 +125,8 @@ CLASS net/minecraft/client/Minecraft
 		ARG 8 resourcePackDir
 		ARG 9 networkProxy
 		ARG 10 gameVersion
+	METHOD <init> (Lnet/minecraft/class_2332;)V
+		ARG 1 args
 	METHOD main ([Ljava/lang/String;)V
 		ARG 0 argv
 	METHOD method_2907 isIntegratedServerRunning ()Z
@@ -168,6 +168,7 @@ CLASS net/minecraft/client/Minecraft
 	METHOD method_2937 getGameFolder ()Ljava/io/File;
 	METHOD method_2939 printCrashReport (Lnet/minecraft/class_1;)V
 		ARG 1 crashReport
+	METHOD method_2940 getOS ()Lnet/minecraft/class_342;
 	METHOD method_2942 onCrash (Lnet/minecraft/class_1;)V
 		ARG 1 report
 	METHOD method_2943 isCommand (Ljava/lang/String;)Z

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler2.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler2.mapping
@@ -1,5 +1,5 @@
-CLASS net/minecraft/class_469 net/minecraft/client/network/ClientLoopbackPlayNetworkHandler
-	COMMENT Used for connecting to the integrated server.
+CLASS net/minecraft/class_469 net/minecraft/client/network/ClientPlayNetworkHandler2
+	COMMENT Used for connecting to a server.
 	FIELD field_1617 stateManager Lnet/minecraft/class_106;
 	FIELD field_1620 random Ljava/util/Random;
 	FIELD field_1621 disconnected Z
@@ -31,7 +31,7 @@ CLASS net/minecraft/class_469 net/minecraft/client/network/ClientLoopbackPlayNet
 		ARG 1 id
 	METHOD method_1198 encode (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 string
-	METHOD method_1199 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	METHOD method_1199 getJoinServerToken (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 		ARG 1 username
 		ARG 2 sessionId
 		ARG 3 serverId

--- a/mappings/net/minecraft/client/util/ScreenshotUtils.mapping
+++ b/mappings/net/minecraft/client/util/ScreenshotUtils.mapping
@@ -3,6 +3,17 @@ CLASS net/minecraft/class_352 net/minecraft/client/util/ScreenshotUtils
 	FIELD field_1034 intBuffer Ljava/nio/IntBuffer;
 	FIELD field_1035 screenshotBuffer [I
 	FIELD field_7697 LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD method_6665 saveScreenshot (Ljava/io/File;IILnet/minecraft/class_1862;)Lnet/minecraft/class_1982;
+		ARG 0 parent
+		ARG 1 textureWidth
+		ARG 2 textureHeight
+		ARG 3 buffer
+	METHOD method_6666 saveScreenshot (Ljava/io/File;Ljava/lang/String;IILnet/minecraft/class_1862;)Lnet/minecraft/class_1982;
+		ARG 0 parent
+		ARG 1 name
+		ARG 2 textureWidth
+		ARG 3 textureHeight
+		ARG 4 buffer
 	METHOD method_885 getScreenshotFile (Ljava/io/File;)Ljava/io/File;
 		ARG 0 screenshotsDirectory
 	METHOD method_886 saveScreenshot (Ljava/io/File;II)Ljava/lang/String;
@@ -21,14 +32,3 @@ CLASS net/minecraft/class_352 net/minecraft/client/util/ScreenshotUtils
 		ARG 0 src
 		ARG 1 width
 		ARG 2 height
-	METHOD method_6665 saveScreenshot (Ljava/io/File;IILnet/minecraft/class_1862;)Lnet/minecraft/class_1982;
-		ARG 0 parent
-		ARG 1 textureWidth
-		ARG 2 textureHeight
-		ARG 3 buffer
-	METHOD method_6666 saveScreenshot (Ljava/io/File;Ljava/lang/String;IILnet/minecraft/class_1862;)Lnet/minecraft/class_1982;
-		ARG 0 parent
-		ARG 1 name
-		ARG 2 textureWidth
-		ARG 3 textureHeight
-		ARG 4 buffer

--- a/mappings/net/minecraft/client/util/ScreenshotUtils.mapping
+++ b/mappings/net/minecraft/client/util/ScreenshotUtils.mapping
@@ -1,7 +1,26 @@
 CLASS net/minecraft/class_352 net/minecraft/client/util/ScreenshotUtils
 	FIELD field_1033 DATE_FORMAT Ljava/text/DateFormat;
 	FIELD field_1034 intBuffer Ljava/nio/IntBuffer;
+	FIELD field_1035 screenshotBuffer [I
 	FIELD field_7697 LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD method_885 getScreenshotFile (Ljava/io/File;)Ljava/io/File;
+		ARG 0 screenshotsDirectory
+	METHOD method_886 saveScreenshot (Ljava/io/File;II)Ljava/lang/String;
+		ARG 0 dataDir
+		ARG 1 width
+		ARG 2 height
+	METHOD method_887 saveScreenshot (Ljava/io/File;Ljava/lang/String;II)Ljava/lang/String;
+		ARG 0 dataDir
+		ARG 1 customName
+		ARG 2 width
+		ARG 3 height
+	METHOD method_888 correctOrientation ([III)V
+		COMMENT rotates the src image / matrix,
+		COMMENT used because {@link org.lwjgl.opengl.GL11#glReadPixels} might
+		COMMENT return pixel data in a different orientation than expected.
+		ARG 0 src
+		ARG 1 width
+		ARG 2 height
 	METHOD method_6665 saveScreenshot (Ljava/io/File;IILnet/minecraft/class_1862;)Lnet/minecraft/class_1982;
 		ARG 0 parent
 		ARG 1 textureWidth
@@ -13,5 +32,3 @@ CLASS net/minecraft/class_352 net/minecraft/client/util/ScreenshotUtils
 		ARG 2 textureWidth
 		ARG 3 textureHeight
 		ARG 4 buffer
-	METHOD method_885 getScreenshotFile (Ljava/io/File;)Ljava/io/File;
-		ARG 0 screenshotsDirectory

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -5,18 +5,18 @@ CLASS net/minecraft/class_478 net/minecraft/client/world/ClientWorld
 	FIELD field_1661 clientNetHandler Lnet/minecraft/class_1845;
 	FIELD field_1662 clientChunkCache Lnet/minecraft/class_476;
 	FIELD field_1664 world Ljava/util/Set;
-	METHOD <init> (Lnet/minecraft/class_469;Lnet/minecraft/class_1156;IILnet/minecraft/class_839;Lnet/minecraft/class_1555;)V
-		ARG 2 levelInfo
-		ARG 3 dimension
-		ARG 4 difficulty
-		ARG 5 profiler
-		ARG 6 logger
 	METHOD <init> (Lnet/minecraft/class_1845;Lnet/minecraft/class_1156;ILnet/minecraft/class_2151;Lnet/minecraft/class_839;)V
 		ARG 1 netHandler
 		ARG 2 levelInfo
 		ARG 3 dimensionId
 		ARG 4 difficulty
 		ARG 5 profiler
+	METHOD <init> (Lnet/minecraft/class_469;Lnet/minecraft/class_1156;IILnet/minecraft/class_839;Lnet/minecraft/class_1555;)V
+		ARG 2 levelInfo
+		ARG 3 dimension
+		ARG 4 difficulty
+		ARG 5 profiler
+		ARG 6 logger
 	METHOD method_1248 spawnRandomParticles (III)V
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -5,18 +5,18 @@ CLASS net/minecraft/class_478 net/minecraft/client/world/ClientWorld
 	FIELD field_1661 clientNetHandler Lnet/minecraft/class_1845;
 	FIELD field_1662 clientChunkCache Lnet/minecraft/class_476;
 	FIELD field_1664 world Ljava/util/Set;
-	METHOD <init> (Lnet/minecraft/class_1845;Lnet/minecraft/class_1156;ILnet/minecraft/class_2151;Lnet/minecraft/class_839;)V
-		ARG 1 netHandler
-		ARG 2 levelInfo
-		ARG 3 dimensionId
-		ARG 4 difficulty
-		ARG 5 profiler
 	METHOD <init> (Lnet/minecraft/class_469;Lnet/minecraft/class_1156;IILnet/minecraft/class_839;Lnet/minecraft/class_1555;)V
 		ARG 2 levelInfo
 		ARG 3 dimension
 		ARG 4 difficulty
 		ARG 5 profiler
 		ARG 6 logger
+	METHOD <init> (Lnet/minecraft/class_1845;Lnet/minecraft/class_1156;ILnet/minecraft/class_2151;Lnet/minecraft/class_839;)V
+		ARG 1 netHandler
+		ARG 2 levelInfo
+		ARG 3 dimensionId
+		ARG 4 difficulty
+		ARG 5 profiler
 	METHOD method_1248 spawnRandomParticles (III)V
 		ARG 1 x
 		ARG 2 y
@@ -26,6 +26,7 @@ CLASS net/minecraft/class_478 net/minecraft/client/world/ClientWorld
 		ARG 1 x
 		ARG 2 z
 		ARG 3 load
+	METHOD method_1253 spawnPainting (ILnet/minecraft/class_864;)V
 	METHOD method_1255 removeEntity (I)Lnet/minecraft/class_864;
 		ARG 1 id
 	METHOD method_5131 setScoreboard (Lnet/minecraft/class_1471;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -1,4 +1,30 @@
 CLASS net/minecraft/class_864 net/minecraft/entity/Entity
+	FIELD field_11899 HITBOX Lnet/minecraft/class_231;
+	FIELD field_11900 lastPortalBlockPos Lnet/minecraft/class_2552;
+	FIELD field_11901 lastPortalVec3d Lnet/minecraft/class_236;
+	FIELD field_11902 teleportDirection Lnet/minecraft/class_1354;
+	FIELD field_11903 commandStats Lnet/minecraft/class_2598;
+	FIELD field_11904 outsideWorldBorder Z
+	FIELD field_14493 CUSTOM_NAME Lnet/minecraft/class_2921;
+	FIELD field_14494 NAME_VISIBLE Lnet/minecraft/class_2921;
+	FIELD field_14495 SILENT Lnet/minecraft/class_2921;
+	FIELD field_14497 scoreboardTags Ljava/util/Set;
+	FIELD field_14498 teleportRequested Z
+	FIELD field_14499 LOGGER_ Lorg/apache/logging/log4j/Logger;
+	FIELD field_14500 tracedX J
+	FIELD field_14501 tracedY J
+	FIELD field_14502 tracedZ J
+	FIELD field_14503 uuidString Ljava/lang/String;
+	FIELD field_14504 isGlowing Z
+	FIELD field_14505 mount Lnet/minecraft/class_864;
+	FIELD field_14506 FLAGS Lnet/minecraft/class_2921;
+	FIELD field_14507 AIR Lnet/minecraft/class_2921;
+	FIELD field_14508 passengerList Ljava/util/List;
+	FIELD field_14509 ridingCooldown I
+	FIELD field_15028 NO_GRAVITY Lnet/minecraft/class_2921;
+	FIELD field_15443 pistonMovementDelta [D
+	FIELD field_15445 EMPTY_STACK_LIST Ljava/util/List;
+	FIELD field_16512 nextSoundDistance F
 	FIELD field_3193 pitch F
 	FIELD field_3194 prevYaw F
 	FIELD field_3195 prevPitch F
@@ -73,32 +99,6 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 	FIELD field_6116 playerUuid Ljava/util/UUID;
 	FIELD field_6117 teleporting Z
 	FIELD field_9080 entityId I
-	FIELD field_11899 HITBOX Lnet/minecraft/class_231;
-	FIELD field_11900 lastPortalBlockPos Lnet/minecraft/class_2552;
-	FIELD field_11901 lastPortalVec3d Lnet/minecraft/class_236;
-	FIELD field_11902 teleportDirection Lnet/minecraft/class_1354;
-	FIELD field_11903 commandStats Lnet/minecraft/class_2598;
-	FIELD field_11904 outsideWorldBorder Z
-	FIELD field_14493 CUSTOM_NAME Lnet/minecraft/class_2921;
-	FIELD field_14494 NAME_VISIBLE Lnet/minecraft/class_2921;
-	FIELD field_14495 SILENT Lnet/minecraft/class_2921;
-	FIELD field_14497 scoreboardTags Ljava/util/Set;
-	FIELD field_14498 teleportRequested Z
-	FIELD field_14499 LOGGER_ Lorg/apache/logging/log4j/Logger;
-	FIELD field_14500 tracedX J
-	FIELD field_14501 tracedY J
-	FIELD field_14502 tracedZ J
-	FIELD field_14503 uuidString Ljava/lang/String;
-	FIELD field_14504 isGlowing Z
-	FIELD field_14505 mount Lnet/minecraft/class_864;
-	FIELD field_14506 FLAGS Lnet/minecraft/class_2921;
-	FIELD field_14507 AIR Lnet/minecraft/class_2921;
-	FIELD field_14508 passengerList Ljava/util/List;
-	FIELD field_14509 ridingCooldown I
-	FIELD field_15028 NO_GRAVITY Lnet/minecraft/class_2921;
-	FIELD field_15443 pistonMovementDelta [D
-	FIELD field_15445 EMPTY_STACK_LIST Ljava/util/List;
-	FIELD field_16512 nextSoundDistance F
 	METHOD <init> (Lnet/minecraft/class_1150;)V
 		COMMENT All classes that extend Entity <b>must</b> have a constructor
 		COMMENT that takes in one, and only one {@link net.minecraft.world.World} parameter.
@@ -110,6 +110,181 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 		ARG 2 world
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 object
+	METHOD method_10927 kill ()V
+	METHOD method_10928 isSilent ()Z
+	METHOD method_10929 attemptSprintingParticles ()V
+	METHOD method_10930 spawnSprintingParticles ()V
+	METHOD method_10931 rayTrace (DF)Lnet/minecraft/class_234;
+		ARG 1 maxDistance
+		ARG 3 tickDelta
+	METHOD method_10932 getBlastResistance (Lnet/minecraft/class_1147;Lnet/minecraft/class_1150;Lnet/minecraft/class_2552;Lnet/minecraft/class_2232;)F
+		ARG 1 explosion
+		ARG 2 world
+		ARG 3 pos
+		ARG 4 state
+	METHOD method_10933 canExplosionDestroyBlock (Lnet/minecraft/class_1147;Lnet/minecraft/class_1150;Lnet/minecraft/class_2552;Lnet/minecraft/class_2232;F)Z
+		ARG 1 explosion
+		ARG 2 world
+		ARG 3 pos
+		ARG 4 state
+		ARG 5 explosionPower
+	METHOD method_10934 setBoundingBox (Lnet/minecraft/class_231;)V
+		ARG 1 boundingBox
+	METHOD method_10935 refreshPositionAndAngles (Lnet/minecraft/class_2552;FF)V
+		ARG 1 pos
+		ARG 2 yaw
+		ARG 3 pitch
+	METHOD method_10936 playStepSound (Lnet/minecraft/class_2552;Lnet/minecraft/class_197;)V
+		ARG 1 pos
+		ARG 2 block
+	METHOD method_10937 isSpectatedBy (Lnet/minecraft/class_798;)Z
+		ARG 1 player
+	METHOD method_10938 dealDamage (Lnet/minecraft/class_1699;Lnet/minecraft/class_864;)V
+		ARG 1 attacker
+		ARG 2 target
+	METHOD method_10939 interactAt (Lnet/minecraft/class_988;Lnet/minecraft/class_236;)Z
+		ARG 1 player
+		ARG 2 hitPos
+	METHOD method_10940 getLastNetherPortalDirectionVector ()Lnet/minecraft/class_236;
+	METHOD method_10941 getLastNetherPortalDirection ()Lnet/minecraft/class_1354;
+	METHOD method_10942 isCustomNameVisible ()Z
+	METHOD method_10943 getHorizontalDirection ()Lnet/minecraft/class_1354;
+	METHOD method_10944 getHoverEvent ()Lnet/minecraft/class_1984;
+	METHOD method_10945 getBoundingBox ()Lnet/minecraft/class_231;
+	METHOD method_10946 isOutsideWorldBorder ()Z
+	METHOD method_10947 getCommandStats ()Lnet/minecraft/class_2598;
+	METHOD method_10949 isImmuneToExplosion ()Z
+	METHOD method_10950 isTouchingLava ()Z
+	METHOD method_10951 doesNotCollide (Lnet/minecraft/class_231;)Z
+		ARG 1 box
+	METHOD method_10952 squaredDistanceTo (Lnet/minecraft/class_2552;)D
+		ARG 1 pos
+	METHOD method_10953 isInvulnerableTo (Lnet/minecraft/class_856;)Z
+		ARG 1 damageSource
+	METHOD method_10954 setSilent (Z)V
+		ARG 1 silent
+	METHOD method_10955 squaredDistanceToCenter (Lnet/minecraft/class_2552;)D
+		ARG 1 pos
+	METHOD method_10956 equip (ILnet/minecraft/class_1071;)Z
+		ARG 1 slot
+		ARG 2 item
+	METHOD method_10957 setInNetherPortal (Lnet/minecraft/class_2552;)V
+		ARG 1 pos
+	METHOD method_10958 getCameraPosVec (F)Lnet/minecraft/class_236;
+		ARG 1 tickDelta
+	METHOD method_10959 getRotationVector (FF)Lnet/minecraft/class_236;
+		ARG 1 pitch
+		ARG 2 yaw
+	METHOD method_10960 setYaw (F)V
+		ARG 1 yaw
+	METHOD method_10961 fromClientNbt (Lnet/minecraft/class_322;)V
+		ARG 1 nbt
+	METHOD method_10962 setCustomNameVisible (Z)V
+		ARG 1 visible
+	METHOD method_10963 setOutsideWorldBorder (Z)V
+		ARG 1 value
+	METHOD method_10964 updateSubmergedInWaterState ()V
+	METHOD method_12966 tickNetherPortalCooldown ()V
+	METHOD method_12967 getScoreboardTags ()Ljava/util/Set;
+	METHOD method_12968 applyMirror (Lnet/minecraft/class_2727;)F
+		ARG 1 mirror
+	METHOD method_12969 applyRotation (Lnet/minecraft/class_2734;)F
+		ARG 1 rotation
+	METHOD method_12970 isTeamPlayer (Lnet/minecraft/class_1599;)Z
+		ARG 1 team
+	METHOD method_12971 getPassengersDeep (Ljava/lang/Class;Ljava/util/Set;)V
+		ARG 1 type
+	METHOD method_12972 addScoreboardTag (Ljava/lang/String;)Z
+		ARG 1 tag
+	METHOD method_12973 setUuid (Ljava/util/UUID;)V
+		ARG 1 uuid
+	METHOD method_12974 onTrackedDataSet (Lnet/minecraft/class_2921;)V
+		ARG 1 data
+	METHOD method_12975 startRiding (Lnet/minecraft/class_864;Z)Z
+		ARG 1 entity
+		ARG 2 force
+	METHOD method_12976 interactAt (Lnet/minecraft/class_988;Lnet/minecraft/class_236;Lnet/minecraft/class_2961;)Lnet/minecraft/class_2962;
+		ARG 1 player
+		ARG 2 hitPos
+		ARG 3 hand
+	METHOD method_12977 getItemsHand ()Ljava/lang/Iterable;
+	METHOD method_12978 getArmorItems ()Ljava/lang/Iterable;
+	METHOD method_12979 getItemsEquipped ()Ljava/lang/Iterable;
+	METHOD method_12980 hasMount ()Z
+	METHOD method_12981 hasPassengers ()Z
+	METHOD method_12982 isGlowing ()Z
+	METHOD method_12983 canUsePortals ()Z
+	METHOD method_12986 removeAllPassengers ()V
+	METHOD method_12987 setRenderDistanceMultiplier (D)V
+		ARG 0 value
+	METHOD method_12988 getPassengersDeep (Ljava/lang/Class;)Ljava/util/Collection;
+		ARG 1 type
+	METHOD method_12989 removeScoreboardTag (Ljava/lang/String;)Z
+		ARG 1 tag
+	METHOD method_12990 onStartedTrackingBy (Lnet/minecraft/class_798;)V
+		ARG 1 player
+	METHOD method_12992 getSoundCategory ()Lnet/minecraft/class_2153;
+	METHOD method_12993 getEntityName ()Ljava/lang/String;
+	METHOD method_12994 getRenderDistanceMultiplier ()D
+	METHOD method_12995 getMovementDirection ()Lnet/minecraft/class_1354;
+	METHOD method_12996 getVisibilityBoundingBox ()Lnet/minecraft/class_231;
+	METHOD method_12997 entityDataRequiresOperator ()Z
+	METHOD method_12998 teleportRequested ()Z
+	METHOD method_12999 getPrimaryPassenger ()Lnet/minecraft/class_864;
+	METHOD method_13000 getPassengerList ()Ljava/util/List;
+	METHOD method_13001 getPassengersDeep ()Ljava/util/Collection;
+	METHOD method_13002 getRootVehicle ()Lnet/minecraft/class_864;
+		COMMENT Gets the lowest entity this entity is riding.
+	METHOD method_13004 getVehicle ()Lnet/minecraft/class_864;
+	METHOD method_13005 onStoppedTrackingBy (Lnet/minecraft/class_798;)V
+		ARG 1 player
+	METHOD method_13006 toNbt (Lnet/minecraft/class_322;)Lnet/minecraft/class_322;
+		ARG 1 nbt
+	METHOD method_13007 setGlowing (Z)V
+		ARG 1 glowing
+	METHOD method_13008 setInvulnerable (Z)V
+		ARG 1 invulnerable
+	METHOD method_13009 updatePassengerPosition (Lnet/minecraft/class_864;)V
+		ARG 1 passenger
+	METHOD method_13010 onPassengerLookAround (Lnet/minecraft/class_864;)V
+		ARG 1 passenger
+	METHOD method_13011 ride (Lnet/minecraft/class_864;)Z
+		ARG 1 entity
+	METHOD method_13012 canStartRiding (Lnet/minecraft/class_864;)Z
+		ARG 1 entity
+	METHOD method_13013 addPassenger (Lnet/minecraft/class_864;)V
+		ARG 1 passenger
+	METHOD method_13014 stopRiding ()V
+	METHOD method_13015 removePassenger (Lnet/minecraft/class_864;)V
+		ARG 1 passenger
+	METHOD method_13016 canAddPassenger (Lnet/minecraft/class_864;)Z
+		ARG 1 passenger
+	METHOD method_13017 isTeammate (Lnet/minecraft/class_864;)Z
+		ARG 1 other
+	METHOD method_13018 hasPassenger (Lnet/minecraft/class_864;)Z
+		ARG 1 passenger
+	METHOD method_13019 isConnectedThroughVehicle (Lnet/minecraft/class_864;)Z
+		ARG 1 entity
+	METHOD method_13020 hasPassengerDeep (Lnet/minecraft/class_864;)Z
+		ARG 1 passenger
+	METHOD method_13021 getPistonBehavior ()Lnet/minecraft/class_2768;
+	METHOD method_13489 getRotationClient ()Lnet/minecraft/class_3019;
+	METHOD method_13490 getRotationVecClient ()Lnet/minecraft/class_236;
+	METHOD method_13491 hasNoGravity ()Z
+	METHOD method_13492 setNoGravity (Z)V
+		ARG 1 noGravity
+	METHOD method_13931 isInvulnerable ()Z
+	METHOD method_13932 registerDataFixes (Lnet/minecraft/class_2934;)V
+		ARG 0 dataFixer
+	METHOD method_13933 getBurningDuration ()I
+	METHOD method_15049 onBlockCollision (Lnet/minecraft/class_2232;)V
+		ARG 1 state
+	METHOD method_15050 updateKilledAchievement (Lnet/minecraft/class_864;ILnet/minecraft/class_856;)V
+		ARG 1 killer
+		ARG 2 score
+		ARG 3 source
+	METHOD method_15053 getLightmapCoordinates ()I
+	METHOD method_15054 getBrightnessAtEyes ()F
 	METHOD method_2460 setOnFireFromLava ()V
 	METHOD method_2461 extinguish ()V
 	METHOD method_2462 destroy ()V
@@ -405,178 +580,3 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 		ARG 3 y
 		ARG 5 z
 	METHOD method_8365 getEntityId ()I
-	METHOD method_10927 kill ()V
-	METHOD method_10928 isSilent ()Z
-	METHOD method_10929 attemptSprintingParticles ()V
-	METHOD method_10930 spawnSprintingParticles ()V
-	METHOD method_10931 rayTrace (DF)Lnet/minecraft/class_234;
-		ARG 1 maxDistance
-		ARG 3 tickDelta
-	METHOD method_10932 getBlastResistance (Lnet/minecraft/class_1147;Lnet/minecraft/class_1150;Lnet/minecraft/class_2552;Lnet/minecraft/class_2232;)F
-		ARG 1 explosion
-		ARG 2 world
-		ARG 3 pos
-		ARG 4 state
-	METHOD method_10933 canExplosionDestroyBlock (Lnet/minecraft/class_1147;Lnet/minecraft/class_1150;Lnet/minecraft/class_2552;Lnet/minecraft/class_2232;F)Z
-		ARG 1 explosion
-		ARG 2 world
-		ARG 3 pos
-		ARG 4 state
-		ARG 5 explosionPower
-	METHOD method_10934 setBoundingBox (Lnet/minecraft/class_231;)V
-		ARG 1 boundingBox
-	METHOD method_10935 refreshPositionAndAngles (Lnet/minecraft/class_2552;FF)V
-		ARG 1 pos
-		ARG 2 yaw
-		ARG 3 pitch
-	METHOD method_10936 playStepSound (Lnet/minecraft/class_2552;Lnet/minecraft/class_197;)V
-		ARG 1 pos
-		ARG 2 block
-	METHOD method_10937 isSpectatedBy (Lnet/minecraft/class_798;)Z
-		ARG 1 player
-	METHOD method_10938 dealDamage (Lnet/minecraft/class_1699;Lnet/minecraft/class_864;)V
-		ARG 1 attacker
-		ARG 2 target
-	METHOD method_10939 interactAt (Lnet/minecraft/class_988;Lnet/minecraft/class_236;)Z
-		ARG 1 player
-		ARG 2 hitPos
-	METHOD method_10940 getLastNetherPortalDirectionVector ()Lnet/minecraft/class_236;
-	METHOD method_10941 getLastNetherPortalDirection ()Lnet/minecraft/class_1354;
-	METHOD method_10942 isCustomNameVisible ()Z
-	METHOD method_10943 getHorizontalDirection ()Lnet/minecraft/class_1354;
-	METHOD method_10944 getHoverEvent ()Lnet/minecraft/class_1984;
-	METHOD method_10945 getBoundingBox ()Lnet/minecraft/class_231;
-	METHOD method_10946 isOutsideWorldBorder ()Z
-	METHOD method_10947 getCommandStats ()Lnet/minecraft/class_2598;
-	METHOD method_10949 isImmuneToExplosion ()Z
-	METHOD method_10950 isTouchingLava ()Z
-	METHOD method_10951 doesNotCollide (Lnet/minecraft/class_231;)Z
-		ARG 1 box
-	METHOD method_10952 squaredDistanceTo (Lnet/minecraft/class_2552;)D
-		ARG 1 pos
-	METHOD method_10953 isInvulnerableTo (Lnet/minecraft/class_856;)Z
-		ARG 1 damageSource
-	METHOD method_10954 setSilent (Z)V
-		ARG 1 silent
-	METHOD method_10955 squaredDistanceToCenter (Lnet/minecraft/class_2552;)D
-		ARG 1 pos
-	METHOD method_10956 equip (ILnet/minecraft/class_1071;)Z
-		ARG 1 slot
-		ARG 2 item
-	METHOD method_10957 setInNetherPortal (Lnet/minecraft/class_2552;)V
-		ARG 1 pos
-	METHOD method_10958 getCameraPosVec (F)Lnet/minecraft/class_236;
-		ARG 1 tickDelta
-	METHOD method_10959 getRotationVector (FF)Lnet/minecraft/class_236;
-		ARG 1 pitch
-		ARG 2 yaw
-	METHOD method_10960 setYaw (F)V
-		ARG 1 yaw
-	METHOD method_10961 fromClientNbt (Lnet/minecraft/class_322;)V
-		ARG 1 nbt
-	METHOD method_10962 setCustomNameVisible (Z)V
-		ARG 1 visible
-	METHOD method_10963 setOutsideWorldBorder (Z)V
-		ARG 1 value
-	METHOD method_10964 updateSubmergedInWaterState ()V
-	METHOD method_12966 tickNetherPortalCooldown ()V
-	METHOD method_12967 getScoreboardTags ()Ljava/util/Set;
-	METHOD method_12968 applyMirror (Lnet/minecraft/class_2727;)F
-		ARG 1 mirror
-	METHOD method_12969 applyRotation (Lnet/minecraft/class_2734;)F
-		ARG 1 rotation
-	METHOD method_12970 isTeamPlayer (Lnet/minecraft/class_1599;)Z
-		ARG 1 team
-	METHOD method_12971 getPassengersDeep (Ljava/lang/Class;Ljava/util/Set;)V
-		ARG 1 type
-	METHOD method_12972 addScoreboardTag (Ljava/lang/String;)Z
-		ARG 1 tag
-	METHOD method_12973 setUuid (Ljava/util/UUID;)V
-		ARG 1 uuid
-	METHOD method_12974 onTrackedDataSet (Lnet/minecraft/class_2921;)V
-		ARG 1 data
-	METHOD method_12975 startRiding (Lnet/minecraft/class_864;Z)Z
-		ARG 1 entity
-		ARG 2 force
-	METHOD method_12976 interactAt (Lnet/minecraft/class_988;Lnet/minecraft/class_236;Lnet/minecraft/class_2961;)Lnet/minecraft/class_2962;
-		ARG 1 player
-		ARG 2 hitPos
-		ARG 3 hand
-	METHOD method_12977 getItemsHand ()Ljava/lang/Iterable;
-	METHOD method_12978 getArmorItems ()Ljava/lang/Iterable;
-	METHOD method_12979 getItemsEquipped ()Ljava/lang/Iterable;
-	METHOD method_12980 hasMount ()Z
-	METHOD method_12981 hasPassengers ()Z
-	METHOD method_12982 isGlowing ()Z
-	METHOD method_12983 canUsePortals ()Z
-	METHOD method_12986 removeAllPassengers ()V
-	METHOD method_12987 setRenderDistanceMultiplier (D)V
-		ARG 0 value
-	METHOD method_12988 getPassengersDeep (Ljava/lang/Class;)Ljava/util/Collection;
-		ARG 1 type
-	METHOD method_12989 removeScoreboardTag (Ljava/lang/String;)Z
-		ARG 1 tag
-	METHOD method_12990 onStartedTrackingBy (Lnet/minecraft/class_798;)V
-		ARG 1 player
-	METHOD method_12992 getSoundCategory ()Lnet/minecraft/class_2153;
-	METHOD method_12993 getEntityName ()Ljava/lang/String;
-	METHOD method_12994 getRenderDistanceMultiplier ()D
-	METHOD method_12995 getMovementDirection ()Lnet/minecraft/class_1354;
-	METHOD method_12996 getVisibilityBoundingBox ()Lnet/minecraft/class_231;
-	METHOD method_12997 entityDataRequiresOperator ()Z
-	METHOD method_12998 teleportRequested ()Z
-	METHOD method_12999 getPrimaryPassenger ()Lnet/minecraft/class_864;
-	METHOD method_13000 getPassengerList ()Ljava/util/List;
-	METHOD method_13001 getPassengersDeep ()Ljava/util/Collection;
-	METHOD method_13002 getRootVehicle ()Lnet/minecraft/class_864;
-		COMMENT Gets the lowest entity this entity is riding.
-	METHOD method_13004 getVehicle ()Lnet/minecraft/class_864;
-	METHOD method_13005 onStoppedTrackingBy (Lnet/minecraft/class_798;)V
-		ARG 1 player
-	METHOD method_13006 toNbt (Lnet/minecraft/class_322;)Lnet/minecraft/class_322;
-		ARG 1 nbt
-	METHOD method_13007 setGlowing (Z)V
-		ARG 1 glowing
-	METHOD method_13008 setInvulnerable (Z)V
-		ARG 1 invulnerable
-	METHOD method_13009 updatePassengerPosition (Lnet/minecraft/class_864;)V
-		ARG 1 passenger
-	METHOD method_13010 onPassengerLookAround (Lnet/minecraft/class_864;)V
-		ARG 1 passenger
-	METHOD method_13011 ride (Lnet/minecraft/class_864;)Z
-		ARG 1 entity
-	METHOD method_13012 canStartRiding (Lnet/minecraft/class_864;)Z
-		ARG 1 entity
-	METHOD method_13013 addPassenger (Lnet/minecraft/class_864;)V
-		ARG 1 passenger
-	METHOD method_13014 stopRiding ()V
-	METHOD method_13015 removePassenger (Lnet/minecraft/class_864;)V
-		ARG 1 passenger
-	METHOD method_13016 canAddPassenger (Lnet/minecraft/class_864;)Z
-		ARG 1 passenger
-	METHOD method_13017 isTeammate (Lnet/minecraft/class_864;)Z
-		ARG 1 other
-	METHOD method_13018 hasPassenger (Lnet/minecraft/class_864;)Z
-		ARG 1 passenger
-	METHOD method_13019 isConnectedThroughVehicle (Lnet/minecraft/class_864;)Z
-		ARG 1 entity
-	METHOD method_13020 hasPassengerDeep (Lnet/minecraft/class_864;)Z
-		ARG 1 passenger
-	METHOD method_13021 getPistonBehavior ()Lnet/minecraft/class_2768;
-	METHOD method_13489 getRotationClient ()Lnet/minecraft/class_3019;
-	METHOD method_13490 getRotationVecClient ()Lnet/minecraft/class_236;
-	METHOD method_13491 hasNoGravity ()Z
-	METHOD method_13492 setNoGravity (Z)V
-		ARG 1 noGravity
-	METHOD method_13931 isInvulnerable ()Z
-	METHOD method_13932 registerDataFixes (Lnet/minecraft/class_2934;)V
-		ARG 0 dataFixer
-	METHOD method_13933 getBurningDuration ()I
-	METHOD method_15049 onBlockCollision (Lnet/minecraft/class_2232;)V
-		ARG 1 state
-	METHOD method_15050 updateKilledAchievement (Lnet/minecraft/class_864;ILnet/minecraft/class_856;)V
-		ARG 1 killer
-		ARG 2 score
-		ARG 3 source
-	METHOD method_15053 getLightmapCoordinates ()I
-	METHOD method_15054 getBrightnessAtEyes ()F

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -1,30 +1,4 @@
 CLASS net/minecraft/class_864 net/minecraft/entity/Entity
-	FIELD field_11899 HITBOX Lnet/minecraft/class_231;
-	FIELD field_11900 lastPortalBlockPos Lnet/minecraft/class_2552;
-	FIELD field_11901 lastPortalVec3d Lnet/minecraft/class_236;
-	FIELD field_11902 teleportDirection Lnet/minecraft/class_1354;
-	FIELD field_11903 commandStats Lnet/minecraft/class_2598;
-	FIELD field_11904 outsideWorldBorder Z
-	FIELD field_14493 CUSTOM_NAME Lnet/minecraft/class_2921;
-	FIELD field_14494 NAME_VISIBLE Lnet/minecraft/class_2921;
-	FIELD field_14495 SILENT Lnet/minecraft/class_2921;
-	FIELD field_14497 scoreboardTags Ljava/util/Set;
-	FIELD field_14498 teleportRequested Z
-	FIELD field_14499 LOGGER_ Lorg/apache/logging/log4j/Logger;
-	FIELD field_14500 tracedX J
-	FIELD field_14501 tracedY J
-	FIELD field_14502 tracedZ J
-	FIELD field_14503 uuidString Ljava/lang/String;
-	FIELD field_14504 isGlowing Z
-	FIELD field_14505 mount Lnet/minecraft/class_864;
-	FIELD field_14506 FLAGS Lnet/minecraft/class_2921;
-	FIELD field_14507 AIR Lnet/minecraft/class_2921;
-	FIELD field_14508 passengerList Ljava/util/List;
-	FIELD field_14509 ridingCooldown I
-	FIELD field_15028 NO_GRAVITY Lnet/minecraft/class_2921;
-	FIELD field_15443 pistonMovementDelta [D
-	FIELD field_15445 EMPTY_STACK_LIST Ljava/util/List;
-	FIELD field_16512 nextSoundDistance F
 	FIELD field_3193 pitch F
 	FIELD field_3194 prevYaw F
 	FIELD field_3195 prevPitch F
@@ -35,6 +9,8 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 	FIELD field_3200 colliding Z
 	FIELD field_3201 velocityModified Z
 	FIELD field_3202 inLava Z
+	FIELD field_3203 freeze Z
+		COMMENT seems to set velocity X, Y, and Z to `0` when set
 	FIELD field_3204 removed Z
 	FIELD field_3205 heightOffset F
 	FIELD field_3206 width F
@@ -62,6 +38,7 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 	FIELD field_3229 chunkZ I
 	FIELD field_3230 ignoreCameraFrustum Z
 	FIELD field_3231 velocityDirty Z
+	FIELD field_3232 entityBoundary Lnet/minecraft/class_866;
 	FIELD field_3234 fireTicks I
 	FIELD field_3235 skinUrl Ljava/lang/String;
 	FIELD field_3237 trackedX I
@@ -96,6 +73,32 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 	FIELD field_6116 playerUuid Ljava/util/UUID;
 	FIELD field_6117 teleporting Z
 	FIELD field_9080 entityId I
+	FIELD field_11899 HITBOX Lnet/minecraft/class_231;
+	FIELD field_11900 lastPortalBlockPos Lnet/minecraft/class_2552;
+	FIELD field_11901 lastPortalVec3d Lnet/minecraft/class_236;
+	FIELD field_11902 teleportDirection Lnet/minecraft/class_1354;
+	FIELD field_11903 commandStats Lnet/minecraft/class_2598;
+	FIELD field_11904 outsideWorldBorder Z
+	FIELD field_14493 CUSTOM_NAME Lnet/minecraft/class_2921;
+	FIELD field_14494 NAME_VISIBLE Lnet/minecraft/class_2921;
+	FIELD field_14495 SILENT Lnet/minecraft/class_2921;
+	FIELD field_14497 scoreboardTags Ljava/util/Set;
+	FIELD field_14498 teleportRequested Z
+	FIELD field_14499 LOGGER_ Lorg/apache/logging/log4j/Logger;
+	FIELD field_14500 tracedX J
+	FIELD field_14501 tracedY J
+	FIELD field_14502 tracedZ J
+	FIELD field_14503 uuidString Ljava/lang/String;
+	FIELD field_14504 isGlowing Z
+	FIELD field_14505 mount Lnet/minecraft/class_864;
+	FIELD field_14506 FLAGS Lnet/minecraft/class_2921;
+	FIELD field_14507 AIR Lnet/minecraft/class_2921;
+	FIELD field_14508 passengerList Ljava/util/List;
+	FIELD field_14509 ridingCooldown I
+	FIELD field_15028 NO_GRAVITY Lnet/minecraft/class_2921;
+	FIELD field_15443 pistonMovementDelta [D
+	FIELD field_15445 EMPTY_STACK_LIST Ljava/util/List;
+	FIELD field_16512 nextSoundDistance F
 	METHOD <init> (Lnet/minecraft/class_1150;)V
 		COMMENT All classes that extend Entity <b>must</b> have a constructor
 		COMMENT that takes in one, and only one {@link net.minecraft.world.World} parameter.
@@ -107,6 +110,301 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 		ARG 2 world
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 object
+	METHOD method_2460 setOnFireFromLava ()V
+	METHOD method_2461 extinguish ()V
+	METHOD method_2462 destroy ()V
+	METHOD method_2463 checkBlockCollision ()V
+	METHOD method_2464 getBox ()Lnet/minecraft/class_231;
+	METHOD method_2465 isFireImmune ()Z
+	METHOD method_2466 tickFire ()Z
+	METHOD method_2467 isTouchingWater ()Z
+		COMMENT Returns whether this entity's hitbox is touching water fluid.
+	METHOD method_2468 updateWaterState ()Z
+	METHOD method_2470 scheduleVelocityUpdate ()V
+	METHOD method_2471 collides ()Z
+	METHOD method_2472 isPushable ()Z
+	METHOD method_2473 getTexture ()Ljava/lang/String;
+	METHOD method_2474 getSavedEntityId ()Ljava/lang/String;
+	METHOD method_2476 isAlive ()Z
+	METHOD method_2477 isInsideWall ()Z
+	METHOD method_2478 tickRiding ()V
+	METHOD method_2479 updatePassengerPosition ()V
+	METHOD method_2480 getHeightOffset ()D
+	METHOD method_2481 getMountedHeightOffset ()D
+	METHOD method_2482 getTargetingMargin ()F
+	METHOD method_2483 getRotation ()Lnet/minecraft/class_236;
+	METHOD method_2484 initDataTracker ()V
+	METHOD method_2485 handleStatus (B)V
+		ARG 1 status
+	METHOD method_2486 shouldRender (D)Z
+		ARG 1 distance
+	METHOD method_2487 updatePositionAndAngles (DDDFF)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+		ARG 7 yaw
+		ARG 8 pitch
+	METHOD method_2488 setPositionAndRotation (DDDFFI)V
+		COMMENT Sets the position and rotation of an entity.
+		ARG 1 x
+			COMMENT the X position
+		ARG 3 y
+			COMMENT the Y position
+		ARG 5 z
+			COMMENT the Z position
+		ARG 7 yaw
+			COMMENT the yaw angle
+		ARG 8 pitch
+			COMMENT the pitch angle
+		ARG 9 a3
+			COMMENT seems to always be 3 (in 1.3.2)
+	METHOD method_2488 updateTrackedPositionAndAngles (DDDFFIZ)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+		ARG 7 yaw
+		ARG 8 pitch
+		ARG 9 interpolationSteps
+		ARG 10 interpolate
+	METHOD method_2489 fall (DZLnet/minecraft/class_197;Lnet/minecraft/class_2552;)V
+		ARG 1 heightDifference
+		ARG 3 onGround
+		ARG 4 landedBlock
+		ARG 5 landedPosition
+	METHOD method_2489 fall (DZLnet/minecraft/class_2232;Lnet/minecraft/class_2552;)V
+		ARG 1 heightDifference
+		ARG 3 onGround
+		ARG 4 landedState
+		ARG 5 landedPos
+	METHOD method_2490 handleFallDamage (FF)V
+		ARG 1 fallDistance
+		ARG 2 damageMultiplier
+	METHOD method_2491 setBounds (FF)V
+		ARG 1 width
+		ARG 2 height
+	METHOD method_2492 updateVelocity (FFF)V
+	METHOD method_2493 dropItem (Lnet/minecraft/class_1069;IF)Lnet/minecraft/class_964;
+		ARG 1 item
+		ARG 2 count
+		ARG 3 yOffset
+	METHOD method_2495 setFlag (IZ)V
+		ARG 1 index
+		ARG 2 value
+	METHOD method_2496 isSubmergedIn (Lnet/minecraft/class_63;)Z
+		ARG 1 material
+	METHOD method_2497 shouldRender (Lnet/minecraft/class_236;)Z
+		ARG 1 cameraPos
+	METHOD method_2498 readCustomDataFromNbt (Lnet/minecraft/class_322;)V
+		ARG 1 nbt
+	METHOD method_2499 damage (Lnet/minecraft/class_856;F)Z
+		ARG 1 source
+		ARG 2 amount
+	METHOD method_2499 damage (Lnet/minecraft/class_856;I)Z
+		ARG 1 source
+		ARG 2 damage
+	METHOD method_2500 startRiding (Lnet/minecraft/class_864;)V
+		ARG 1 entity
+	METHOD method_2502 onLightningStrike (Lnet/minecraft/class_961;)V
+		ARG 1 lightning
+	METHOD method_2503 dropItem (Lnet/minecraft/class_1071;F)Lnet/minecraft/class_964;
+		ARG 1 stack
+		ARG 2 yOffset
+	METHOD method_2504 setWorld (Lnet/minecraft/class_1150;)V
+		ARG 1 world
+	METHOD method_2505 setSneaking (Z)V
+		ARG 1 sneaking
+	METHOD method_2506 toListNbt ([D)Lnet/minecraft/class_474;
+		ARG 1 values
+	METHOD method_2507 toListNbt ([F)Lnet/minecraft/class_474;
+		ARG 1 values
+	METHOD method_2508 enterNetherPortal ()V
+	METHOD method_2509 animateDamage ()V
+	METHOD method_2511 isOnFire ()Z
+	METHOD method_2512 hasVehicle ()Z
+	METHOD method_2513 isSneaking ()Z
+	METHOD method_2514 isSprinting ()Z
+	METHOD method_2515 isSwimming ()Z
+	METHOD method_2516 getAir ()I
+	METHOD method_2517 setInLava ()V
+	METHOD method_2518 getTranslationKey ()Ljava/lang/String;
+	METHOD method_2519 getParts ()[Lnet/minecraft/class_864;
+	METHOD method_2520 getHeadRotation ()F
+	METHOD method_2521 isAttackable ()Z
+	METHOD method_2522 updatePosition (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_2523 refreshPositionAndAngles (DDDFF)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+		ARG 7 yaw
+		ARG 8 pitch
+	METHOD method_2524 getLightmapCoordinates (F)I
+	METHOD method_2525 setRotation (FF)V
+		COMMENT Sets the {@code yaw} and {@code pitch}, (both) modulo'd by {@code 360} degrees.
+		ARG 1 yaw
+		ARG 2 pitch
+	METHOD method_2526 dropItem (Lnet/minecraft/class_1069;I)Lnet/minecraft/class_964;
+		ARG 1 item
+		ARG 2 yOffset
+	METHOD method_2527 setArmorSlot (ILnet/minecraft/class_1071;)V
+		ARG 1 armorSlot
+		ARG 2 item
+	METHOD method_2527 equipStack (Lnet/minecraft/class_2968;Lnet/minecraft/class_1071;)V
+		ARG 1 slot
+		ARG 2 stack
+	METHOD method_2528 writeCustomDataToNbt (Lnet/minecraft/class_322;)V
+		ARG 1 nbt
+	METHOD method_2529 setSprinting (Z)V
+		ARG 1 sprinting
+	METHOD method_2530 onPlayerCollision (Lnet/minecraft/class_988;)V
+		ARG 1 player
+	METHOD method_2531 getArmorStacks ()[Lnet/minecraft/class_1071;
+	METHOD method_2532 doesNotCollide (DDD)Z
+		ARG 1 offsetX
+		ARG 3 offsetY
+		ARG 5 offsetZ
+	METHOD method_2533 getBrightnessAtEyes (F)F
+	METHOD method_2534 increaseTransforms (FF)V
+		ARG 1 yaw
+		ARG 2 pitch
+	METHOD method_2535 saveToNbt (Lnet/minecraft/class_322;)Z
+		ARG 1 nbt
+	METHOD method_2536 updateKilledAdvancementCriterion (Lnet/minecraft/class_864;I)V
+		ARG 1 entity
+		ARG 2 score
+	METHOD method_2538 setSwimming (Z)V
+		ARG 1 swimming
+	METHOD method_2539 move (DDD)V
+		ARG 1 velocityX
+		ARG 3 velocityY
+		ARG 5 velocityZ
+	METHOD method_2539 move (Lnet/minecraft/class_3131;DDD)V
+		ARG 1 type
+		ARG 2 movementX
+		ARG 4 movementY
+		ARG 6 movementZ
+	METHOD method_2540 setHeadYaw (F)V
+		ARG 1 headYaw
+	METHOD method_2541 setOnFireFor (I)V
+		ARG 1 seconds
+	METHOD method_2542 writePlayerData (Lnet/minecraft/class_322;)V
+		ARG 1 nbt
+	METHOD method_2543 distanceTo (Lnet/minecraft/class_864;)F
+		ARG 1 entity
+	METHOD method_2544 getEyeHeight ()F
+	METHOD method_2545 squaredDistanceTo (DDD)D
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_2546 burn (I)V
+		ARG 1 time
+	METHOD method_2547 fromNbt (Lnet/minecraft/class_322;)V
+		ARG 1 nbt
+	METHOD method_2548 squaredDistanceTo (Lnet/minecraft/class_864;)D
+		ARG 1 entity
+	METHOD method_2549 canClimb ()Z
+	METHOD method_2550 distanceTo (DDD)D
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_2551 getFlag (I)Z
+		ARG 1 index
+	METHOD method_2552 pushAwayFrom (Lnet/minecraft/class_864;)V
+		ARG 1 entity
+	METHOD method_2553 addVelocity (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_2554 setAir (I)V
+		ARG 1 air
+	METHOD method_2555 getHardCollisionBox (Lnet/minecraft/class_864;)Lnet/minecraft/class_231;
+		ARG 1 collidingEntity
+	METHOD method_2556 setVelocityClient (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_2558 tick ()V
+	METHOD method_2559 pushOutOfBlocks (DDD)Z
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_2560 isPartOf (Lnet/minecraft/class_864;)Z
+		ARG 1 entity
+	METHOD method_2561 getDataTracker ()Lnet/minecraft/class_878;
+	METHOD method_2562 afterSpawn ()V
+	METHOD method_2563 remove ()V
+	METHOD method_2564 baseTick ()V
+	METHOD method_2577 refreshPositionAfterTeleport (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_3197 changeDimension (I)Lnet/minecraft/class_864;
+		ARG 1 newDimension
+	METHOD method_3197 teleportToDimension (I)V
+		ARG 1 dimensionId
+	METHOD method_3203 onSwimmingStart ()V
+	METHOD method_4441 playSound (Ljava/lang/String;FF)V
+		ARG 1 id
+		ARG 2 volume
+		ARG 3 pitch
+	METHOD method_4441 playSound (Lnet/minecraft/class_2926;FF)V
+		ARG 1 event
+		ARG 2 volume
+		ARG 3 pitch
+	METHOD method_4442 populateCrashReport (Lnet/minecraft/class_1392;)V
+		ARG 1 section
+	METHOD method_4443 copyPortalInfo (Lnet/minecraft/class_864;)V
+		ARG 1 original
+	METHOD method_4443 copyFrom (Lnet/minecraft/class_864;Z)V
+		ARG 1 original
+	METHOD method_4445 getDefaultNetherPortalCooldown ()I
+	METHOD method_4446 isInvisible ()Z
+	METHOD method_4448 getSafeFallDistance ()I
+	METHOD method_4449 getLastNetherPortalAxis ()I
+	METHOD method_4450 canAvoidTraps ()Z
+	METHOD method_4451 doesRenderOnFire ()Z
+	METHOD method_4452 setInvisible (Z)V
+		ARG 1 invisible
+	METHOD method_4453 handleAttack (Lnet/minecraft/class_864;)Z
+		ARG 1 attacker
+	METHOD method_4454 copyPosition (Lnet/minecraft/class_864;)V
+		ARG 1 original
+	METHOD method_4455 getMaxNetherPortalTime ()I
+	METHOD method_5339 hasCustomName ()Z
+	METHOD method_5380 canFly ()Z
+	METHOD method_5381 getLocalizationKey ()Ljava/lang/String;
+	METHOD method_5382 saveSelfToNbt (Lnet/minecraft/class_322;)Z
+		ARG 1 nbt
+	METHOD method_5383 isInvisibleTo (Lnet/minecraft/class_988;)Z
+		ARG 1 player
+	METHOD method_5394 shouldRenderName ()Z
+	METHOD method_5411 setCustomName (Ljava/lang/String;)V
+		ARG 1 name
+	METHOD method_5427 getCustomName ()Ljava/lang/String;
+	METHOD method_6096 shouldSetPositionOnLoad ()Z
+	METHOD method_6098 onKilledOther (Lnet/minecraft/class_1699;)V
+		ARG 1 other
+	METHOD method_6099 getUuid ()Ljava/util/UUID;
+	METHOD method_6100 openInventory (Lnet/minecraft/class_988;)Z
+		ARG 1 player
+	METHOD method_6100 interact (Lnet/minecraft/class_988;Lnet/minecraft/class_2961;)Z
+		ARG 1 player
+		ARG 2 hand
+	METHOD method_6135 getScoreboardTeam ()Lnet/minecraft/class_1599;
+	METHOD method_6146 getRotationVector (F)Lnet/minecraft/class_236;
+		ARG 1 vector
+	METHOD method_6344 getName ()Lnet/minecraft/class_1982;
+	METHOD method_8360 getSwimSound ()Ljava/lang/String;
+	METHOD method_8361 getSplashSound ()Ljava/lang/String;
+	METHOD method_8362 setEntityId (I)V
+		ARG 1 id
+	METHOD method_8363 shouldRender (DDD)Z
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD method_8365 getEntityId ()I
 	METHOD method_10927 kill ()V
 	METHOD method_10928 isSilent ()Z
 	METHOD method_10929 attemptSprintingParticles ()V
@@ -282,283 +580,3 @@ CLASS net/minecraft/class_864 net/minecraft/entity/Entity
 		ARG 3 source
 	METHOD method_15053 getLightmapCoordinates ()I
 	METHOD method_15054 getBrightnessAtEyes ()F
-	METHOD method_2460 setOnFireFromLava ()V
-	METHOD method_2461 extinguish ()V
-	METHOD method_2462 destroy ()V
-	METHOD method_2463 checkBlockCollision ()V
-	METHOD method_2464 getBox ()Lnet/minecraft/class_231;
-	METHOD method_2465 isFireImmune ()Z
-	METHOD method_2466 tickFire ()Z
-	METHOD method_2467 isTouchingWater ()Z
-		COMMENT Returns whether this entity's hitbox is touching water fluid.
-	METHOD method_2468 updateWaterState ()Z
-	METHOD method_2470 scheduleVelocityUpdate ()V
-	METHOD method_2471 collides ()Z
-	METHOD method_2472 isPushable ()Z
-	METHOD method_2473 getTexture ()Ljava/lang/String;
-	METHOD method_2474 getSavedEntityId ()Ljava/lang/String;
-	METHOD method_2476 isAlive ()Z
-	METHOD method_2477 isInsideWall ()Z
-	METHOD method_2478 tickRiding ()V
-	METHOD method_2479 updatePassengerPosition ()V
-	METHOD method_2480 getHeightOffset ()D
-	METHOD method_2481 getMountedHeightOffset ()D
-	METHOD method_2482 getTargetingMargin ()F
-	METHOD method_2483 getRotation ()Lnet/minecraft/class_236;
-	METHOD method_2484 initDataTracker ()V
-	METHOD method_2485 handleStatus (B)V
-		ARG 1 status
-	METHOD method_2486 shouldRender (D)Z
-		ARG 1 distance
-	METHOD method_2487 updatePositionAndAngles (DDDFF)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-		ARG 7 yaw
-		ARG 8 pitch
-	METHOD method_2488 updateTrackedPositionAndAngles (DDDFFIZ)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-		ARG 7 yaw
-		ARG 8 pitch
-		ARG 9 interpolationSteps
-		ARG 10 interpolate
-	METHOD method_2489 fall (DZLnet/minecraft/class_197;Lnet/minecraft/class_2552;)V
-		ARG 1 heightDifference
-		ARG 3 onGround
-		ARG 4 landedBlock
-		ARG 5 landedPosition
-	METHOD method_2489 fall (DZLnet/minecraft/class_2232;Lnet/minecraft/class_2552;)V
-		ARG 1 heightDifference
-		ARG 3 onGround
-		ARG 4 landedState
-		ARG 5 landedPos
-	METHOD method_2490 handleFallDamage (FF)V
-		ARG 1 fallDistance
-		ARG 2 damageMultiplier
-	METHOD method_2491 setBounds (FF)V
-		ARG 1 width
-		ARG 2 height
-	METHOD method_2492 updateVelocity (FFF)V
-	METHOD method_2493 dropItem (Lnet/minecraft/class_1069;IF)Lnet/minecraft/class_964;
-		ARG 1 item
-		ARG 2 count
-		ARG 3 yOffset
-	METHOD method_2495 setFlag (IZ)V
-		ARG 1 index
-		ARG 2 value
-	METHOD method_2496 isSubmergedIn (Lnet/minecraft/class_63;)Z
-		ARG 1 material
-	METHOD method_2497 shouldRender (Lnet/minecraft/class_236;)Z
-		ARG 1 cameraPos
-	METHOD method_2498 readCustomDataFromNbt (Lnet/minecraft/class_322;)V
-		ARG 1 nbt
-	METHOD method_2499 damage (Lnet/minecraft/class_856;F)Z
-		ARG 1 source
-		ARG 2 amount
-	METHOD method_2499 damage (Lnet/minecraft/class_856;I)Z
-		ARG 1 source
-		ARG 2 damage
-	METHOD method_2500 startRiding (Lnet/minecraft/class_864;)V
-		ARG 1 entity
-	METHOD method_2502 onLightningStrike (Lnet/minecraft/class_961;)V
-		ARG 1 lightning
-	METHOD method_2503 dropItem (Lnet/minecraft/class_1071;F)Lnet/minecraft/class_964;
-		ARG 1 stack
-		ARG 2 yOffset
-	METHOD method_2504 setWorld (Lnet/minecraft/class_1150;)V
-		ARG 1 world
-	METHOD method_2505 setSneaking (Z)V
-		ARG 1 sneaking
-	METHOD method_2506 toListNbt ([D)Lnet/minecraft/class_474;
-		ARG 1 values
-	METHOD method_2507 toListNbt ([F)Lnet/minecraft/class_474;
-		ARG 1 values
-	METHOD method_2508 enterNetherPortal ()V
-	METHOD method_2509 animateDamage ()V
-	METHOD method_2511 isOnFire ()Z
-	METHOD method_2512 hasVehicle ()Z
-	METHOD method_2513 isSneaking ()Z
-	METHOD method_2514 isSprinting ()Z
-	METHOD method_2515 isSwimming ()Z
-	METHOD method_2516 getAir ()I
-	METHOD method_2517 setInLava ()V
-	METHOD method_2518 getTranslationKey ()Ljava/lang/String;
-	METHOD method_2519 getParts ()[Lnet/minecraft/class_864;
-	METHOD method_2520 getHeadRotation ()F
-	METHOD method_2521 isAttackable ()Z
-	METHOD method_2522 updatePosition (DDD)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_2523 refreshPositionAndAngles (DDDFF)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-		ARG 7 yaw
-		ARG 8 pitch
-	METHOD method_2524 getLightmapCoordinates (F)I
-	METHOD method_2525 setRotation (FF)V
-		ARG 1 yaw
-		ARG 2 pitch
-	METHOD method_2526 dropItem (Lnet/minecraft/class_1069;I)Lnet/minecraft/class_964;
-		ARG 1 item
-		ARG 2 yOffset
-	METHOD method_2527 setArmorSlot (ILnet/minecraft/class_1071;)V
-		ARG 1 armorSlot
-		ARG 2 item
-	METHOD method_2527 equipStack (Lnet/minecraft/class_2968;Lnet/minecraft/class_1071;)V
-		ARG 1 slot
-		ARG 2 stack
-	METHOD method_2528 writeCustomDataToNbt (Lnet/minecraft/class_322;)V
-		ARG 1 nbt
-	METHOD method_2529 setSprinting (Z)V
-		ARG 1 sprinting
-	METHOD method_2530 onPlayerCollision (Lnet/minecraft/class_988;)V
-		ARG 1 player
-	METHOD method_2531 getArmorStacks ()[Lnet/minecraft/class_1071;
-	METHOD method_2532 doesNotCollide (DDD)Z
-		ARG 1 offsetX
-		ARG 3 offsetY
-		ARG 5 offsetZ
-	METHOD method_2533 getBrightnessAtEyes (F)F
-	METHOD method_2534 increaseTransforms (FF)V
-		ARG 1 yaw
-		ARG 2 pitch
-	METHOD method_2535 saveToNbt (Lnet/minecraft/class_322;)Z
-		ARG 1 nbt
-	METHOD method_2536 updateKilledAdvancementCriterion (Lnet/minecraft/class_864;I)V
-		ARG 1 entity
-		ARG 2 score
-	METHOD method_2538 setSwimming (Z)V
-		ARG 1 swimming
-	METHOD method_2539 move (DDD)V
-		ARG 1 velocityX
-		ARG 3 velocityY
-		ARG 5 velocityZ
-	METHOD method_2539 move (Lnet/minecraft/class_3131;DDD)V
-		ARG 1 type
-		ARG 2 movementX
-		ARG 4 movementY
-		ARG 6 movementZ
-	METHOD method_2540 setHeadYaw (F)V
-		ARG 1 headYaw
-	METHOD method_2541 setOnFireFor (I)V
-		ARG 1 seconds
-	METHOD method_2542 writePlayerData (Lnet/minecraft/class_322;)V
-		ARG 1 nbt
-	METHOD method_2543 distanceTo (Lnet/minecraft/class_864;)F
-		ARG 1 entity
-	METHOD method_2544 getEyeHeight ()F
-	METHOD method_2545 squaredDistanceTo (DDD)D
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_2546 burn (I)V
-		ARG 1 time
-	METHOD method_2547 fromNbt (Lnet/minecraft/class_322;)V
-		ARG 1 nbt
-	METHOD method_2548 squaredDistanceTo (Lnet/minecraft/class_864;)D
-		ARG 1 entity
-	METHOD method_2549 canClimb ()Z
-	METHOD method_2550 distanceTo (DDD)D
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_2551 getFlag (I)Z
-		ARG 1 index
-	METHOD method_2552 pushAwayFrom (Lnet/minecraft/class_864;)V
-		ARG 1 entity
-	METHOD method_2553 addVelocity (DDD)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_2554 setAir (I)V
-		ARG 1 air
-	METHOD method_2555 getHardCollisionBox (Lnet/minecraft/class_864;)Lnet/minecraft/class_231;
-		ARG 1 collidingEntity
-	METHOD method_2556 setVelocityClient (DDD)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_2558 tick ()V
-	METHOD method_2559 pushOutOfBlocks (DDD)Z
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_2560 isPartOf (Lnet/minecraft/class_864;)Z
-		ARG 1 entity
-	METHOD method_2561 getDataTracker ()Lnet/minecraft/class_878;
-	METHOD method_2562 afterSpawn ()V
-	METHOD method_2563 remove ()V
-	METHOD method_2564 baseTick ()V
-	METHOD method_2577 refreshPositionAfterTeleport (DDD)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_3197 changeDimension (I)Lnet/minecraft/class_864;
-		ARG 1 newDimension
-	METHOD method_3197 teleportToDimension (I)V
-		ARG 1 dimensionId
-	METHOD method_3203 onSwimmingStart ()V
-	METHOD method_4441 playSound (Ljava/lang/String;FF)V
-		ARG 1 id
-		ARG 2 volume
-		ARG 3 pitch
-	METHOD method_4441 playSound (Lnet/minecraft/class_2926;FF)V
-		ARG 1 event
-		ARG 2 volume
-		ARG 3 pitch
-	METHOD method_4442 populateCrashReport (Lnet/minecraft/class_1392;)V
-		ARG 1 section
-	METHOD method_4443 copyPortalInfo (Lnet/minecraft/class_864;)V
-		ARG 1 original
-	METHOD method_4443 copyFrom (Lnet/minecraft/class_864;Z)V
-		ARG 1 original
-	METHOD method_4445 getDefaultNetherPortalCooldown ()I
-	METHOD method_4446 isInvisible ()Z
-	METHOD method_4448 getSafeFallDistance ()I
-	METHOD method_4449 getLastNetherPortalAxis ()I
-	METHOD method_4450 canAvoidTraps ()Z
-	METHOD method_4451 doesRenderOnFire ()Z
-	METHOD method_4452 setInvisible (Z)V
-		ARG 1 invisible
-	METHOD method_4453 handleAttack (Lnet/minecraft/class_864;)Z
-		ARG 1 attacker
-	METHOD method_4454 copyPosition (Lnet/minecraft/class_864;)V
-		ARG 1 original
-	METHOD method_4455 getMaxNetherPortalTime ()I
-	METHOD method_5339 hasCustomName ()Z
-	METHOD method_5380 canFly ()Z
-	METHOD method_5381 getLocalizationKey ()Ljava/lang/String;
-	METHOD method_5382 saveSelfToNbt (Lnet/minecraft/class_322;)Z
-		ARG 1 nbt
-	METHOD method_5383 isInvisibleTo (Lnet/minecraft/class_988;)Z
-		ARG 1 player
-	METHOD method_5394 shouldRenderName ()Z
-	METHOD method_5411 setCustomName (Ljava/lang/String;)V
-		ARG 1 name
-	METHOD method_5427 getCustomName ()Ljava/lang/String;
-	METHOD method_6096 shouldSetPositionOnLoad ()Z
-	METHOD method_6098 onKilledOther (Lnet/minecraft/class_1699;)V
-		ARG 1 other
-	METHOD method_6099 getUuid ()Ljava/util/UUID;
-	METHOD method_6100 openInventory (Lnet/minecraft/class_988;)Z
-		ARG 1 player
-	METHOD method_6100 interact (Lnet/minecraft/class_988;Lnet/minecraft/class_2961;)Z
-		ARG 1 player
-		ARG 2 hand
-	METHOD method_6135 getScoreboardTeam ()Lnet/minecraft/class_1599;
-	METHOD method_6146 getRotationVector (F)Lnet/minecraft/class_236;
-		ARG 1 vector
-	METHOD method_6344 getName ()Lnet/minecraft/class_1982;
-	METHOD method_8360 getSwimSound ()Ljava/lang/String;
-	METHOD method_8361 getSplashSound ()Ljava/lang/String;
-	METHOD method_8362 setEntityId (I)V
-		ARG 1 id
-	METHOD method_8363 shouldRender (DDD)Z
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
-	METHOD method_8365 getEntityId ()I

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -96,9 +96,9 @@ CLASS net/minecraft/class_871 net/minecraft/entity/mob/MobEntity
 	METHOD method_2647 getEntityGroup ()Lnet/minecraft/class_873;
 	METHOD method_2653 damageInternal (Lnet/minecraft/class_856;I)V
 		ARG 1 source
-			COMMENT The source of the damage, unused.
+			COMMENT the source of the damage (unused in base implementation)
 		ARG 2 damage
-			COMMENT The amount of damage to be taken
+			COMMENT the amount of damage to be taken
 	METHOD method_2658 shouldApplyEffect (Lnet/minecraft/class_861;)Z
 		COMMENT This will return {@code false} if the entity's group is {@link EntityGroup#UNDEAD}
 		COMMENT and the effect is a {@link StatusEffect#REGENERATION} or {@link StatusEffect#POISON} effect.

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -63,7 +63,7 @@ CLASS net/minecraft/class_871 net/minecraft/entity/mob/MobEntity
 	METHOD method_2594 getMinAmbientSoundDelay ()I
 	METHOD method_2595 playAmbientSound ()V
 	METHOD method_2598 playSpawnEffects ()V
-	METHOD method_2599 getMaximumHealth ()I
+	METHOD method_2599 getMaxHealth ()I
 	METHOD method_2600 getHealth ()I
 	METHOD method_2603 getAmbientSound ()Ljava/lang/String;
 	METHOD method_2603 ambientSound ()Lnet/minecraft/class_2926;

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -63,6 +63,8 @@ CLASS net/minecraft/class_871 net/minecraft/entity/mob/MobEntity
 	METHOD method_2594 getMinAmbientSoundDelay ()I
 	METHOD method_2595 playAmbientSound ()V
 	METHOD method_2598 playSpawnEffects ()V
+	METHOD method_2599 getMaximumHealth ()I
+	METHOD method_2600 getHealth ()I
 	METHOD method_2603 getAmbientSound ()Ljava/lang/String;
 	METHOD method_2603 ambientSound ()Lnet/minecraft/class_2926;
 	METHOD method_2604 getHurtSound ()Ljava/lang/String;
@@ -92,12 +94,19 @@ CLASS net/minecraft/class_871 net/minecraft/entity/mob/MobEntity
 	METHOD method_2645 isUndeadGroup ()Z
 	METHOD method_2646 getSpeed ()F
 	METHOD method_2647 getEntityGroup ()Lnet/minecraft/class_873;
+	METHOD method_2653 damageInternal (Lnet/minecraft/class_856;I)V
+		ARG 1 source
+			COMMENT The source of the damage, unused.
+		ARG 2 damage
+			COMMENT The amount of damage to be taken
 	METHOD method_2658 shouldApplyEffect (Lnet/minecraft/class_861;)Z
 		COMMENT This will return {@code false} if the entity's group is {@link EntityGroup#UNDEAD}
 		COMMENT and the effect is a {@link StatusEffect#REGENERATION} or {@link StatusEffect#POISON} effect.
 		ARG 1 effect
 	METHOD method_2659 setForwardSpeed (F)V
 		ARG 1 forwardSpeed
+	METHOD method_2668 setHealth (I)V
+		ARG 1 health
 	METHOD method_2672 dropRandomItem (I)V
 	METHOD method_2674 removeEffect (I)V
 		ARG 1 index

--- a/mappings/net/minecraft/entity/player/ControllablePlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/ControllablePlayerEntity.mapping
@@ -1,5 +1,9 @@
 CLASS net/minecraft/class_481 net/minecraft/entity/player/ControllablePlayerEntity
+	FIELD field_1667 netHandler Lnet/minecraft/class_469;
 	METHOD <init> (Lnet/minecraft/client/Minecraft;Lnet/minecraft/class_1150;Lnet/minecraft/class_355;Lnet/minecraft/class_469;)V
 		ARG 1 client
 		ARG 2 world
 		ARG 3 session
+	METHOD method_1262 sendMessage (Ljava/lang/String;)V
+		COMMENT Sends a chat message packet.
+		ARG 1 message

--- a/mappings/net/minecraft/entity/player/ControllablePlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/ControllablePlayerEntity.mapping
@@ -7,3 +7,9 @@ CLASS net/minecraft/class_481 net/minecraft/entity/player/ControllablePlayerEnti
 	METHOD method_1262 sendMessage (Ljava/lang/String;)V
 		COMMENT Sends a chat message packet.
 		ARG 1 message
+	METHOD method_2653 (Lnet/minecraft/class_856;I)V
+		COMMENT Used internally by {@link net.minecraft.entity.mob.MobEntity#damage} to actually damage the player
+		ARG 1
+			COMMENT The source of the damage, unused.
+		ARG 2
+			COMMENT The amount of damage to be taken

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -142,6 +142,7 @@ CLASS net/minecraft/class_988 net/minecraft/entity/player/PlayerEntity
 		ARG 1 potion
 	METHOD method_3205 canConsume (Z)Z
 		ARG 1 ignoreHunger
+	METHOD method_3207 swingHand ()V
 	METHOD method_3208 closeHandledScreen ()V
 	METHOD method_3210 addExhaustion (F)V
 		ARG 1 exhaustion

--- a/mappings/net/minecraft/network/class_645.mapping
+++ b/mappings/net/minecraft/network/class_645.mapping
@@ -1,6 +1,0 @@
-CLASS net/minecraft/class_645 net/minecraft/network/class_645
-	FIELD field_2402 id I
-	FIELD field_2403 animationId I
-	METHOD <init> (Lnet/minecraft/class_864;I)V
-		ARG 1 entity
-		ARG 2 animationId

--- a/mappings/net/minecraft/network/packet/c2s/play/EntityAnimationC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/EntityAnimationC2SPacket.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_645 net/minecraft/network/packet/c2s/play/EntityAnimationC2SPacket
+	COMMENT A "animation" packet..?
+	COMMENT it's used for critical particles too, so I don't know; but it is used for swinging.
+	FIELD field_2402 id I
+	FIELD field_2403 animationId I
+	METHOD <init> (Lnet/minecraft/class_864;I)V
+		ARG 1 entity
+		ARG 2 animationId


### PR DESCRIPTION
Also fixes the `ClientPlayNetworkHandler` being called `ClientLoopbackPlayNetworkHandler`, even though it is used for more than the integrated server. Might be because there's another thing being mapped as `ClientLoopbackPlayNetworkHandler`, but it's for a newer version.